### PR TITLE
Add support for local execution in nodeletctl

### DIFF
--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/os.sh
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/os.sh
@@ -73,10 +73,20 @@ oom_score = 0
   [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
     [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
       runtime_type = "io.containerd.runc.v2"
-      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+EOF
+
+if [ "$CONTAINERD_CGROUP" = "systemd" ]; then
+    cat >> "/etc/containerd/config.toml" <<EOF
+     [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
         SystemdCgroup = true
 EOF
-    pf9ctr_restart
+else
+   cat >> "/etc/containerd/config.toml" <<EOF
+     [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+        SystemdCgroup = false
+EOF
+fi
+ pf9ctr_restart
 }
 
 

--- a/nodeletctl/go.mod
+++ b/nodeletctl/go.mod
@@ -6,6 +6,7 @@ go 1.16
 
 require (
 	github.com/ghodss/yaml v1.0.0
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/platform9/nodelet/nodelet v0.0.0-20220420170655-9ece5c5b1f61
 	github.com/platform9/pf9ctl v0.0.0-20220112203229-a7beabbd4284

--- a/nodeletctl/go.sum
+++ b/nodeletctl/go.sum
@@ -631,6 +631,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/nodeletctl/pkg/nodeletctl/deployer.go
+++ b/nodeletctl/pkg/nodeletctl/deployer.go
@@ -41,7 +41,7 @@ func NewNodeletDeployer(cfg *BootstrapConfig, sshClient ssh.Client,
 	return deployer
 }
 
-func GetNodeletDeployer(cfg *BootstrapConfig, clusterStatus *ClusterStatus, nodeletCfg *NodeletConfig, nodeName, nodeletSrcFile string, sshKeyFile string) (*NodeletDeployer, error) {
+func GetNodeletDeployer(cfg *BootstrapConfig, clusterStatus *ClusterStatus, nodeletCfg *NodeletConfig, nodeName, nodeletSrcFile string) (*NodeletDeployer, error) {
 	local, err := isLocal(nodeName)
 	if err != nil {
 		return nil, err
@@ -50,9 +50,9 @@ func GetNodeletDeployer(cfg *BootstrapConfig, clusterStatus *ClusterStatus, node
 	if local {
 		sshClient = getLocalClient()
 	} else {
-		sshKey, err := ioutil.ReadFile(sshKeyFile)
+		sshKey, err := ioutil.ReadFile(cfg.SSHPrivateKeyFile)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to read private key: %s", sshKeyFile)
+			return nil, fmt.Errorf("Failed to read private key: %s", cfg.SSHPrivateKeyFile)
 		}
 		sshClient, err = CreateSSHClient(nodeName, cfg.SSHUser, sshKey, 22)
 		if err != nil {

--- a/nodeletctl/pkg/nodeletctl/deployer.go
+++ b/nodeletctl/pkg/nodeletctl/deployer.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -53,7 +54,7 @@ func GetNodeletDeployer(cfg *BootstrapConfig, clusterStatus *ClusterStatus, node
 		if err != nil {
 			return nil, fmt.Errorf("Failed to read private key: %s", sshKeyFile)
 		}
-			sshClient, err = CreateSSHClient(nodeName, cfg.SSHUser, sshKey, 22)
+		sshClient, err = CreateSSHClient(nodeName, cfg.SSHUser, sshKey, 22)
 		if err != nil {
 			return nil, fmt.Errorf("can't create ssh client to host %s, %s", nodeName, err)
 		}
@@ -200,7 +201,7 @@ func (nd *NodeletDeployer) SetOsType() {
 	// TODO: Find actual OS type of remote node once we add Ubuntu support
 	nd.OsType = OsTypeCentos
 
-	stdout, stderr, err := nd.client.RunCommand("cat", "/etc/os-release")
+	stdout, _, err := nd.client.RunCommand("cat /etc/os-release")
 	if err != nil {
 		zap.S().Infof("failed reading data from file: %s", err)
 		return
@@ -210,15 +211,14 @@ func (nd *NodeletDeployer) SetOsType() {
 		nd.OsType = OsTypeUbuntu
 		zap.S().Infof("OS type is Ubuntu")
 	} else {
-		zap.S().Infof("assuming OS type is CentOS, the os string is %s", osString) 	
+		zap.S().Infof("assuming OS type is CentOS, the os string is %s", osString)
 	}
-	
-	
+
 }
 
 func (nd *NodeletDeployer) CreatePf9User() error {
 	zap.S().Infof("Checking pf9 user on node: %s", nd.nodeletCfg.HostId)
-	 _,_, err := nd.client.RunCommand("id -u pf9")
+	_, _, err := nd.client.RunCommand("id -u pf9")
 	if err != nil {
 		zap.S().Infof("User name doesn't exist, proceeding to create")
 	} else {

--- a/nodeletctl/pkg/nodeletctl/deployer.go
+++ b/nodeletctl/pkg/nodeletctl/deployer.go
@@ -199,6 +199,21 @@ func (nd *NodeletDeployer) CopyNodeletConfig() error {
 func (nd *NodeletDeployer) SetOsType() {
 	// TODO: Find actual OS type of remote node once we add Ubuntu support
 	nd.OsType = OsTypeCentos
+
+	stdout, stderr, err := nd.client.RunCommand("cat", "/etc/os-release")
+	if err != nil {
+		zap.S().Infof("failed reading data from file: %s", err)
+		return
+	}
+	osString := strings.ToLower(string(stdout))
+	if strings.Contains(osString, "ubuntu") {
+		nd.OsType = OsTypeUbuntu
+		zap.S().Infof("OS type is Ubuntu")
+	} else {
+		zap.S().Infof("assuming OS type is CentOS, the os string is %s", osString) 	
+	}
+	
+	
 }
 
 func (nd *NodeletDeployer) CreatePf9User() error {

--- a/nodeletctl/pkg/nodeletctl/deployer.go
+++ b/nodeletctl/pkg/nodeletctl/deployer.go
@@ -376,7 +376,15 @@ func UploadFileWrapper(srcFilePath, fileName, dstDir string, client ssh.Client) 
 
 func (nd *NodeletDeployer) DeleteNodelet() error {
 	zap.S().Infof("Deleting nodelet")
-	eraseCmd := "yum erase -y pf9-kube"
+	var eraseCmd string
+	if nd.OsType == OsTypeCentos {
+		eraseCmd = "yum erase -y pf9-kube"
+	} else if nd.OsType == OsTypeUbuntu {
+		eraseCmd = "apt remove -y pf9-kube"
+	} else {
+		return fmt.Errorf("OS type not supported")
+	}
+	
 	zap.S().Infof("Removing nodelet with cmd: %s", eraseCmd)
 	if _, _, err := nd.client.RunCommand(eraseCmd); err != nil {
 		return fmt.Errorf("Failed: %s: %s", eraseCmd, err)

--- a/nodeletctl/pkg/nodeletctl/localExecutor.go
+++ b/nodeletctl/pkg/nodeletctl/localExecutor.go
@@ -1,0 +1,69 @@
+package nodeletctl
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/platform9/pf9ctl/pkg/ssh"
+
+	"github.com/kballard/go-shellquote"
+)
+
+// Client interface provides ways to run command and upload files to remote hosts
+type LocalClient struct {
+}
+
+func getLocalClient() ssh.Client {
+	return &LocalClient{}
+}
+
+// RunCommand executes the remote command returning the stdout, stderr and any error associated with it
+func (client *LocalClient) RunCommand(command string) ([]byte, []byte, error) {
+	var stdoutBuf bytes.Buffer
+	var stderrBuf bytes.Buffer
+	words, err := shellquote.Split(command)
+	if err != nil || len(words) < 1 {
+		return nil, nil, fmt.Errorf("error parsing the command line %s  %v", command, err)
+	}
+	cmd := exec.Command(words[0], words[1:]...)
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+	err = cmd.Run()
+	return stdoutBuf.Bytes(), stderrBuf.Bytes(), err
+}
+
+// Uploadfile uploads the srcFile to remoteDestFilePath and changes the mode to the filemode
+func (client *LocalClient) UploadFile(srcFilePath, remoteDstFilePath string, mode os.FileMode, cb func(read int64, total int64)) error {
+	return copy(srcFilePath, remoteDstFilePath, mode)
+}
+
+// Downloadfile downloads the remoteFile to localFile and changes the mode to the filemode
+func (client *LocalClient) DownloadFile(remoteFile, localPath string, mode os.FileMode, cb func(read int64, total int64)) error {
+	return copy(remoteFile, localPath, mode)
+}
+
+func copy(srcFile, dstFile string, mode os.FileMode) error {
+	src, err := os.Open(srcFile)
+	if err != nil {
+		return fmt.Errorf("error opening file %s, %v", srcFile, err)
+	}
+	defer src.Close()
+	// create new file
+	dest, err := os.Create(dstFile)
+	if err != nil {
+		return fmt.Errorf("error creating remote file %s %v", dstFile, err)
+	}
+	err = dest.Chmod(mode)
+	if err != nil {
+		return fmt.Errorf("error changing the file mode %s, %v", dstFile, err)
+	}
+	defer dest.Close()
+	_, err = io.Copy(dest, src)
+	if err != nil {
+		return fmt.Errorf("error copying %s to %s, %v", srcFile, dstFile, err)
+	}
+	return nil
+}

--- a/nodeletctl/pkg/nodeletctl/localExecutor.go
+++ b/nodeletctl/pkg/nodeletctl/localExecutor.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 
 	"github.com/platform9/pf9ctl/pkg/ssh"
+	"go.uber.org/zap"
 
 	"github.com/kballard/go-shellquote"
 )
@@ -22,6 +23,7 @@ func getLocalClient() ssh.Client {
 
 // RunCommand executes the remote command returning the stdout, stderr and any error associated with it
 func (client *LocalClient) RunCommand(command string) ([]byte, []byte, error) {
+	zap.S().Debugf("Running command: %s", command)
 	var stdoutBuf bytes.Buffer
 	var stderrBuf bytes.Buffer
 	words, err := shellquote.Split(command)
@@ -37,11 +39,13 @@ func (client *LocalClient) RunCommand(command string) ([]byte, []byte, error) {
 
 // Uploadfile uploads the srcFile to remoteDestFilePath and changes the mode to the filemode
 func (client *LocalClient) UploadFile(srcFilePath, remoteDstFilePath string, mode os.FileMode, cb func(read int64, total int64)) error {
+	zap.S().Debugf("Uploading file %s to %s", srcFilePath, remoteDstFilePath)
 	return copy(srcFilePath, remoteDstFilePath, mode)
 }
 
 // Downloadfile downloads the remoteFile to localFile and changes the mode to the filemode
 func (client *LocalClient) DownloadFile(remoteFile, localPath string, mode os.FileMode, cb func(read int64, total int64)) error {
+	zap.S().Debugf("Downloading file %s to %s", remoteFile, localPath)
 	return copy(remoteFile, localPath, mode)
 }
 

--- a/nodeletctl/pkg/nodeletctl/nodeletctl.go
+++ b/nodeletctl/pkg/nodeletctl/nodeletctl.go
@@ -15,25 +15,30 @@ import (
 )
 
 type BootstrapConfig struct {
-	SSHUser                string       `json:"sshUser,omitempty"`
-	SSHPrivateKeyFile      string       `json:"sshPrivateKeyFile,omitempty"`
-	CertsDir               string       `json:"certsDir,omitempty"`
-	KubeConfig             string       `json:"kubeconfig,omitempty"`
-	Pf9KubePkg             string       `json:"nodeletPkg,omitempty"`
-	ClusterId              string       `json:"clusterName,omitempty"`
-	AllowWorkloadsOnMaster bool         `json:"allowWorkloadsOnMaster,omitempty"`
-	K8sApiPort             string       `json:"k8sApiPort,omitempty"`
-	MasterIp               string       `json:"masterIp,omitempty"`
-	MasterVipEnabled       bool         `json:"masterVipEnabled,omitempty"`
-	MasterVipInterface     string       `json:"masterVipInterface,omitempty"`
-	MasterVipVrouterId     int          `json:"masterVipVrouterId,omitempty"`
-	CalicoV4Interface      string       `json:"calicoV4Interface,omitempty"`
-	CalicoV6Interface      string       `json:"calicoV6Interface,omitempty"`
-	MTU                    string       `json:"mtu,omitempty"`
-	Privileged             string       `json:"privileged,omitempty"`
-	ContainerRuntime       string       `json:"containerRuntime,omitempty"`
-	MasterNodes            []HostConfig `json:"masterNodes"`
-	WorkerNodes            []HostConfig `json:"workerNodes"`
+	SSHUser                string                 `json:"sshUser,omitempty"`
+	SSHPrivateKeyFile      string                 `json:"sshPrivateKeyFile,omitempty"`
+	CertsDir               string                 `json:"certsDir,omitempty"`
+	KubeConfig             string                 `json:"kubeconfig,omitempty"`
+	Pf9KubePkg             string                 `json:"nodeletPkg,omitempty"`
+	ClusterId              string                 `json:"clusterName,omitempty"`
+	AllowWorkloadsOnMaster bool                   `json:"allowWorkloadsOnMaster,omitempty"`
+	K8sApiPort             string                 `json:"k8sApiPort,omitempty"`
+	MasterIp               string                 `json:"masterIp,omitempty"`
+	MasterVipEnabled       bool                   `json:"masterVipEnabled,omitempty"`
+	MasterVipInterface     string                 `json:"masterVipInterface,omitempty"`
+	MasterVipVrouterId     int                    `json:"masterVipVrouterId,omitempty"`
+	CalicoV4Interface      string                 `json:"calicoV4Interface,omitempty"`
+	CalicoV6Interface      string                 `json:"calicoV6Interface,omitempty"`
+	MTU                    string                 `json:"mtu,omitempty"`
+	Privileged             string                 `json:"privileged,omitempty"`
+	ContainerRuntime       ContainerRuntimeConfig `json:"containerRuntime,omitempty"`
+	MasterNodes            []HostConfig           `json:"masterNodes"`
+	WorkerNodes            []HostConfig           `json:"workerNodes"`
+}
+
+type ContainerRuntimeConfig struct {
+	Name         string `json:"name,omitempty"`
+	CgroupDriver string `json:"cgroupDriver,omitempty"`
 }
 
 type HostConfig struct {
@@ -45,22 +50,23 @@ type HostConfig struct {
 
 type NodeletConfig struct {
 	AllowWorkloadsOnMaster bool
-	CalicoV4Interface      string
-	CalicoV6Interface      string
-	ClusterId              string
-	ContainerRuntime       string
-	EtcdClusterState       string
-	HostId                 string
-	HostIp                 string
-	K8sApiPort             string
-	MasterList             *map[string]string
-	MasterIp               string
-	MasterVipEnabled       bool
-	MasterVipInterface     string
-	MasterVipVrouterId     int
-	Mtu                    string
-	Privileged             string
-	NodeletRole            string
+
+	CalicoV4Interface  string
+	CalicoV6Interface  string
+	ClusterId          string
+	ContainerRuntime   ContainerRuntimeConfig
+	EtcdClusterState   string
+	HostId             string
+	HostIp             string
+	K8sApiPort         string
+	MasterList         *map[string]string
+	MasterIp           string
+	MasterVipEnabled   bool
+	MasterVipInterface string
+	MasterVipVrouterId int
+	Mtu                string
+	Privileged         string
+	NodeletRole        string
 }
 
 type ClusterStatus struct {
@@ -106,7 +112,7 @@ func InitBootstrapConfig() *BootstrapConfig {
 		CalicoV4Interface:      "first-found",
 		CalicoV6Interface:      "first-found",
 		ClusterId:              DefaultClusterName,
-		ContainerRuntime:       "containerd",
+		ContainerRuntime:       ContainerRuntimeConfig{"containerd", "systemd"},
 		SSHUser:                "root",
 		SSHPrivateKeyFile:      "/root/.ssh/id_rsa",
 		Pf9KubePkg:             NodeletTarSrc,

--- a/nodeletctl/pkg/nodeletctl/templates.go
+++ b/nodeletctl/pkg/nodeletctl/templates.go
@@ -98,7 +98,9 @@ QUAY_PRIVATE_REGISTRY: ""
 REGISTRY_MIRRORS: https://dockermirror.platform9.io/
 RESERVED_CPUS: ""
 ROLE: {{ .NodeletRole }}
-RUNTIME: {{ .ContainerRuntime }}
+RUNTIME: {{ .ContainerRuntime.Name }}
+CONTAINERD_CGROUP:  {{ .ContainerRuntime.CgroupDriver }}
+DOCKER_CGROUP: {{ .ContainerRuntime.CgroupDriver }}
 RUNTIME_CONFIG: ""
 SCHEDULER_FLAGS: ""
 SERVICES_CIDR: 10.21.0.0/22
@@ -174,7 +176,9 @@ QUAY_PRIVATE_REGISTRY: ""
 REGISTRY_MIRRORS: https://dockermirror.platform9.io/
 RESERVED_CPUS: ""
 ROLE: {{ .NodeletRole }}
-RUNTIME: {{ .ContainerRuntime }}
+RUNTIME: {{ .ContainerRuntime.Name }}
+CONTAINERD_CGROUP:  {{ .ContainerRuntime.CgroupDriver }}
+DOCKER_CGROUP: {{ .ContainerRuntime.CgroupDriver }}
 RUNTIME_CONFIG: ""
 SCHEDULER_FLAGS: ""
 SERVICES_CIDR: 10.21.0.0/22


### PR DESCRIPTION
Added support for local machine as an exception and not use
the SSH for local execution. The code stubs out the interface
and runs the commands and copy of the data locally.

Tested manually on the local machine