### PR TITLE
Fixing directory creations in Load user images to container runtime phase

### DIFF
--- a/nodelet/pkg/phases/container_runtime/load_images.go
+++ b/nodelet/pkg/phases/container_runtime/load_images.go
@@ -80,7 +80,7 @@ func (l *LoadImagePhase) Start(ctx context.Context, cfg config.Config) error {
 
 	if _, err := os.Stat(constants.UserImagesDir); os.IsNotExist(err) {
 
-		if err := os.Mkdir(constants.UserImagesDir, os.ModePerm); err != nil {
+		if err := os.MkdirAll(constants.UserImagesDir, os.ModePerm); err != nil {
 			l.log.Error(err.Error())
 			phaseutils.SetHostStatus(l.HostPhase, constants.FailedState, err.Error())
 			return err

--- a/nodelet/pkg/utils/fileio/fileio.go
+++ b/nodelet/pkg/utils/fileio/fileio.go
@@ -264,7 +264,7 @@ func (f *Pf9FileIO) GenerateChecksum(imageDir string) error {
 	}
 	ChecksumDir := fmt.Sprintf("%s/checksum", imageDir)
 	if _, err := os.Stat(ChecksumDir); os.IsNotExist(err) {
-		if err := os.Mkdir(ChecksumDir, os.ModePerm); err != nil {
+		if err := os.MkdirAll(ChecksumDir, os.ModePerm); err != nil {
 			return errors.Wrapf(err, "failed to create directory: %s", ChecksumDir)
 		}
 	}


### PR DESCRIPTION
This fixes the problem of non-existent /var/opt/pf9/images directories when running for the first time by creating necessary parent directories.


{"L":"INFO","T":"2022-05-23T21:58:51.400Z","C":"container_runtime/load_images.go:73","M":"Running Start of phase: Load user images to container runtime"}
{"L":"ERROR","T":"2022-05-23T21:58:51.400Z","C":"container_runtime/load_images.go:79","M":"failed to create directory: /var/opt/pf9/images/checksum: mkdir /var/opt/pf9/images/checksum: no such file or directory"}