### PR TITLE
Regen certs

### DIFF
--- a/nodeletctl/cmd/regenCerts.go
+++ b/nodeletctl/cmd/regenCerts.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/platform9/nodelet/nodeletctl/pkg/nodeletctl"
+	"github.com/spf13/cobra"
+)
+
+var regenCertsCmd = &cobra.Command{
+	Use:   "regen-certs",
+	Short: "Scale up/down a nodelet based cluster",
+	Long:  "Scale up/down a nodelete based cluster",
+
+	RunE: func(command *cobra.Command, args []string) error {
+		err := nodeletctl.RegenClusterCerts(ClusterCfgFile)
+		if err != nil {
+			fmt.Printf("\nFailed to update nodelet cluster: %s\n", err)
+		}
+		return err
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(regenCertsCmd)
+}

--- a/nodeletctl/go.mod
+++ b/nodeletctl/go.mod
@@ -6,7 +6,7 @@ go 1.16
 
 require (
 	github.com/ghodss/yaml v1.0.0
-	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/platform9/nodelet/nodelet v0.0.0-20220420170655-9ece5c5b1f61
 	github.com/platform9/pf9ctl v0.0.0-20220112203229-a7beabbd4284

--- a/nodeletctl/pkg/nodeletctl/certs.go
+++ b/nodeletctl/pkg/nodeletctl/certs.go
@@ -234,3 +234,47 @@ func writeKubeconfigFile(args *KubeConfigData) error {
 	zap.S().Infof("Wrote kubeconfig to %s\n", kubeconfigFile)
 	return nil
 }
+
+func RenewCAIfExpiring(cfg *BootstrapConfig) error {
+	certsDir := filepath.Join(ClusterStateDir, cfg.ClusterId, "certs")
+	caCertFile := filepath.Join(certsDir, RootCACRT)
+
+	caFile, err := ioutil.ReadFile(caCertFile)
+	if err != nil {
+		return fmt.Errorf("Failed to read CA Cert %s: %s", caCertFile, err)
+	}
+	caPEM, _ := pem.Decode(caFile)
+	ca, err := x509.ParseCertificate(caPEM.Bytes)
+	if err != nil {
+		return fmt.Errorf("Failed to parse CA Cert %s: %s", caCertFile, err)
+	}
+
+	currTime := time.Now()
+	expireTime := ca.NotAfter
+
+	diffTime := expireTime.Sub(currTime)
+	daysTillExpiry := int64(diffTime.Hours() / 24)
+	if daysTillExpiry < CAExpiryThreshold {
+		zap.S().Infof("Cert is expiring in %d days (%d hours), will re-generate", daysTillExpiry, diffTime.Hours())
+		return RegenCA(cfg)
+	}
+	return nil
+}
+
+func RegenCA(cfg *BootstrapConfig) error {
+	certsDir := filepath.Join(ClusterStateDir, cfg.ClusterId, "certs")
+	if err := os.RemoveAll(certsDir); err != nil {
+		return fmt.Errorf("Failed to remove old certs directory: %s", err)
+	}
+
+	_, err := GenCALocal(cfg.ClusterId)
+	if err != nil {
+		return fmt.Errorf("Cert regeneration failed: %s\n", err)
+	}
+
+	err = GenKubeconfig(cfg)
+	if err != nil {
+		return fmt.Errorf("Failed to regen kubeconfig with new CA: %s", err)
+	}
+	return nil
+}

--- a/nodeletctl/pkg/nodeletctl/certs.go
+++ b/nodeletctl/pkg/nodeletctl/certs.go
@@ -254,7 +254,7 @@ func RenewCAIfExpiring(cfg *BootstrapConfig) error {
 
 	diffTime := expireTime.Sub(currTime)
 	daysTillExpiry := int64(diffTime.Hours() / 24)
-	if daysTillExpiry < CAExpiryThreshold {
+	if daysTillExpiry < CAExpiryLimitDays {
 		zap.S().Infof("Cert is expiring in %d days (%d hours), will re-generate", daysTillExpiry, diffTime.Hours())
 		return RegenCA(cfg)
 	}

--- a/nodeletctl/pkg/nodeletctl/consts.go
+++ b/nodeletctl/pkg/nodeletctl/consts.go
@@ -15,7 +15,7 @@ const (
 	NodeConverged      = "converging"
 	NodeHealthy        = "ok"
 	CACertExpiryYears  = 3
-	CAExpiryThreshold  = 90
+	CAExpiryLimitDays  = 90
 	RootCACRT          = "rootCA.crt"
 	RootCAKey          = "rootCA.key"
 	AdminKubeconfig    = "admin.kubeconfig"

--- a/nodeletctl/pkg/nodeletctl/consts.go
+++ b/nodeletctl/pkg/nodeletctl/consts.go
@@ -15,6 +15,7 @@ const (
 	NodeConverged      = "converging"
 	NodeHealthy        = "ok"
 	CACertExpiryYears  = 3
+	CAExpiryThreshold  = 90
 	RootCACRT          = "rootCA.crt"
 	RootCAKey          = "rootCA.key"
 	AdminKubeconfig    = "admin.kubeconfig"

--- a/nodeletctl/pkg/nodeletctl/deployer.go
+++ b/nodeletctl/pkg/nodeletctl/deployer.go
@@ -17,6 +17,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
+/* Everything in deployer is a wrapper around shell commands. This is because it executes on
+ * remote machines via an SSH client, so we cannot use native Golang packages.
+ * Add any commands to exec here to onboard the node or install nodelet
+ */
+
 type NodeletDeployer struct {
 	user           string
 	OsType         string
@@ -419,7 +424,7 @@ func (nd *NodeletDeployer) DeleteOldCerts() error {
 	return nil
 }
 
-func (nd *NodeletDeployer) RegenCerts(wg *sync.WaitGroup) error {
+func (nd *NodeletDeployer) UploadCertsAndRestartStack(wg *sync.WaitGroup) error {
 	defer wg.Done()
 
 	if err := nd.UploadCerts(); err != nil {

--- a/nodeletctl/pkg/nodeletctl/nodeletctl.go
+++ b/nodeletctl/pkg/nodeletctl/nodeletctl.go
@@ -641,7 +641,7 @@ func RegenClusterCerts(cfgPath string) error {
 		}*/
 
 		wg.Add(1)
-		go deployer.RegenCerts(&wg)
+		go deployer.UploadCertsAndRestartStack(&wg)
 	}
 	wg.Wait()
 	// This blocks until all nodes are converged/ok


### PR DESCRIPTION
Adds explicit commands regen-certs to revoke old certs and push a new CA. Nodelet code with generate new client certs as normal with the new CA. All nodes are restarted in parallel. This was the only way I could get stack to restart, otherwise each host gets blocked because it can't join etcd cluster with other members still up using old certs

I also added an unused function RenewCAIfExpiring which will generate a new CA if the current one expires in less than 90 days. We can call this during nodeletctl upgrade, so CA will only get upgraded during upgrade if expiring < 90 days. Otherwise use the explicit regen-certs command.