### PR TITLE
Management cluster upgrade

### DIFF
--- a/nodeletctl/cmd/upgrade.go
+++ b/nodeletctl/cmd/upgrade.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/platform9/nodelet/nodeletctl/pkg/nodeletctl"
+	"github.com/spf13/cobra"
+)
+
+var upgradeClusterCmd = &cobra.Command{
+	Use:   "upgrade",
+	Short: "Upgrade a nodelet based cluster",
+	Long:  "Upgrade a DU-less nodelet based management cluster on remote nodes",
+
+	RunE: func(command *cobra.Command, args []string) error {
+		err := nodeletctl.UpgradeCluster(ClusterCfgFile)
+		if err != nil {
+			fmt.Printf("\nFailed to upgrade nodelet cluster: %s\n", err)
+		}
+		return err
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(upgradeClusterCmd)
+}

--- a/nodeletctl/pkg/nodeletctl/deployer.go
+++ b/nodeletctl/pkg/nodeletctl/deployer.go
@@ -30,7 +30,6 @@ type NodeletDeployer struct {
 	nodeletCfg     *NodeletConfig
 	pf9KubeTarSrc  string
 	clusterStatus  *ClusterStatus
-	nodeletPkgName string
 }
 
 func NewNodeletDeployer(cfg *BootstrapConfig, sshClient ssh.Client,
@@ -66,12 +65,6 @@ func GetNodeletDeployer(cfg *BootstrapConfig, clusterStatus *ClusterStatus, node
 	}
 
 	deployer := NewNodeletDeployer(cfg, sshClient, nodeletSrcFile, nodeletCfg, clusterStatus)
-	nodeletPkgName, err := deployer.DetermineKubePkgName()
-	if err != nil {
-		return nil, fmt.Errorf("Error in DetermineKubePkgName: %v", err)
-	}
-	deployer.nodeletPkgName = nodeletPkgName
-
 	return deployer, nil
 }
 
@@ -112,27 +105,11 @@ func isLocal(nodeName string) (bool, error) {
 	return false, nil
 }
 
-func (nd *NodeletDeployer) DetermineKubePkgName() (string, error) {
-
-	// TODO: Determine pkg name from nd.pf9KubeTarSrc, by extracting tar and reading rpm/deb
-	pkgVersion := "1.21.3-pmk.0"
-
-	pkgName := ""
-	if nd.OsType == OsTypeCentos {
-		pkgName = fmt.Sprintf("pf9-kube-%s.x86_64.rpm", pkgVersion)
-	} else if nd.OsType == OsTypeUbuntu {
-		pkgName = fmt.Sprintf("pf9-kube-%s.x86_64.deb", pkgVersion)
-	} else {
-		return "", fmt.Errorf("OS type not supported")
-	}
-	return pkgName, nil
-}
-
 func (nd *NodeletDeployer) UpgradeMaster() error {
 
 	// Uninstall pf9-kube
-	if err := nd.UninstallNodelet("pf9-kube"); err != nil {
-		return fmt.Errorf("Failed to uninstall pf9-kube(nodelet): %s", err)
+	if err := nd.UninstallNodelet("nodelet"); err != nil {
+		return fmt.Errorf("Failed to uninstall nodelet: %s", err)
 	}
 
 	//zap.S().Infof("In UpgradeNode with upgradeToVersionPkgName:", nd.nodeletPkgName)
@@ -143,12 +120,12 @@ func (nd *NodeletDeployer) UpgradeMaster() error {
 
 	// Install new pf9-kube
 	if err := nd.InstallNodelet(); err != nil {
-		return fmt.Errorf("Failed to install pf9-kube(nodelet): %s", err)
+		return fmt.Errorf("Failed to install nodelet: %s", err)
 	}
 
 	// Restart nodeletd
 	if err := nd.RestartNodelet(); err != nil {
-		return fmt.Errorf("Failed to restart pf9-kube(nodelet): %s", err)
+		return fmt.Errorf("Failed to restart nodelet: %s", err)
 	}
 
 	return nil
@@ -157,8 +134,8 @@ func (nd *NodeletDeployer) UpgradeMaster() error {
 func (nd *NodeletDeployer) UpgradeWorker(wg *sync.WaitGroup) {
 	defer wg.Done()
 	// Uninstall pf9-kube
-	if err := nd.UninstallNodelet("pf9-kube"); err != nil {
-		err = fmt.Errorf("Failed to uninstall pf9-kube(nodelet): %s", err)
+	if err := nd.UninstallNodelet("nodelet"); err != nil {
+		err = fmt.Errorf("Failed to uninstall nodelet: %s", err)
 		SetClusterNodeStatus(nd.clusterStatus, nd.nodeletCfg.HostId, "failed", err)
 		//return fmt.Errorf("Failed to uninstall pf9-kube(nodelet): %s", err)
 	}
@@ -172,13 +149,13 @@ func (nd *NodeletDeployer) UpgradeWorker(wg *sync.WaitGroup) {
 
 	// Install new pf9-kube
 	if err := nd.InstallNodelet(); err != nil {
-		err = fmt.Errorf("Failed to install pf9-kube(nodelet): %s", err)
+		err = fmt.Errorf("Failed to install nodelet: %s", err)
 		SetClusterNodeStatus(nd.clusterStatus, nd.nodeletCfg.HostId, "failed", err)
 	}
 
 	// Restart nodeletd
 	if err := nd.RestartNodelet(); err != nil {
-		err = fmt.Errorf("Failed to restart pf9-kube(nodelet): %s", err)
+		err = fmt.Errorf("Failed to restart nodelet: %s", err)
 		SetClusterNodeStatus(nd.clusterStatus, nd.nodeletCfg.HostId, "failed", err)
 	}
 
@@ -352,7 +329,7 @@ func (nd *NodeletDeployer) DetermineNodeletPkgName(nodeletPkgsDir string) (strin
 }
 
 func (nd *NodeletDeployer) UninstallNodelet(nodeletPkgName string) error {
-	zap.S().Infof("Uninstalling nodelet with pkg name:", nodeletPkgName)
+	zap.S().Infof("Uninstalling nodelet with pkg name: %s", nodeletPkgName)
 	uninstallCmd := ""
 	if nd.OsType == OsTypeCentos {
 		uninstallCmd = "yum erase -y " + nodeletPkgName
@@ -370,7 +347,6 @@ func (nd *NodeletDeployer) UninstallNodelet(nodeletPkgName string) error {
 }
 
 func (nd *NodeletDeployer) InstallNodelet() error {
-	zap.S().Infof("Installing nodelet with pkg:", nd.nodeletPkgName)
 	if err := nd.client.UploadFile(nd.pf9KubeTarSrc, NodeletTarDst, 0644, nil); err != nil {
 		return fmt.Errorf("Failed to copy nodelet RPM: %s", err)
 	}

--- a/nodeletctl/pkg/nodeletctl/deployer.go
+++ b/nodeletctl/pkg/nodeletctl/deployer.go
@@ -112,8 +112,6 @@ func (nd *NodeletDeployer) UpgradeMaster() error {
 		return fmt.Errorf("Failed to uninstall nodelet: %s", err)
 	}
 
-	//zap.S().Infof("In UpgradeNode with upgradeToVersionPkgName:", nd.nodeletPkgName)
-
 	if err := nd.CopyNodeletConfig(); err != nil {
 		return fmt.Errorf("failed to copy nodelet config: %s", err)
 	}
@@ -137,26 +135,27 @@ func (nd *NodeletDeployer) UpgradeWorker(wg *sync.WaitGroup) {
 	if err := nd.UninstallNodelet("nodelet"); err != nil {
 		err = fmt.Errorf("Failed to uninstall nodelet: %s", err)
 		SetClusterNodeStatus(nd.clusterStatus, nd.nodeletCfg.HostId, "failed", err)
-		//return fmt.Errorf("Failed to uninstall pf9-kube(nodelet): %s", err)
+		return
 	}
-
-	//zap.S().Infof("In UpgradeNode with upgradeToVersionPkgName:", nd.nodeletPkgName)
 
 	if err := nd.CopyNodeletConfig(); err != nil {
 		err = fmt.Errorf("failed to copy nodelet config: %s", err)
 		SetClusterNodeStatus(nd.clusterStatus, nd.nodeletCfg.HostId, "failed", err)
+		return
 	}
 
 	// Install new pf9-kube
 	if err := nd.InstallNodelet(); err != nil {
 		err = fmt.Errorf("Failed to install nodelet: %s", err)
 		SetClusterNodeStatus(nd.clusterStatus, nd.nodeletCfg.HostId, "failed", err)
+		return
 	}
 
 	// Restart nodeletd
 	if err := nd.RestartNodelet(); err != nil {
 		err = fmt.Errorf("Failed to restart nodelet: %s", err)
 		SetClusterNodeStatus(nd.clusterStatus, nd.nodeletCfg.HostId, "failed", err)
+		return
 	}
 
 }
@@ -198,7 +197,6 @@ func (nd *NodeletDeployer) SpawnWorker(wg *sync.WaitGroup) {
 
 func (nd *NodeletDeployer) DeployNodelet() error {
 	zap.S().Infof("Deploying nodelet: %s", nd.nodeletCfg.HostId)
-
 	if err := nd.CreatePf9User(); err != nil {
 		return fmt.Errorf("failed to create user: %s", err)
 	}

--- a/nodeletctl/pkg/nodeletctl/nodeletctl.go
+++ b/nodeletctl/pkg/nodeletctl/nodeletctl.go
@@ -88,11 +88,6 @@ func CreateCluster(cfgPath string) error {
 		return fmt.Errorf("Failed to Parse Cluster Config: %s", err)
 	}
 
-	if clusterCfg.MasterVipEnabled {
-		rand.Seed(time.Now().UnixNano())
-		clusterCfg.MasterVipVrouterId = rand.Intn(254) + 1
-	}
-
 	if err := DeployCluster(clusterCfg); err != nil {
 		zap.S().Infof("Cluster failed: %s\n", err)
 		return fmt.Errorf("Cluster failed: %s", err)
@@ -112,15 +107,6 @@ func UpgradeCluster(cfgPath string) error {
 	if err != nil {
 		zap.S().Infof("Failed to Parse Cluster Config: %s", err)
 		return fmt.Errorf("Failed to Parse Cluster Config: %s", err)
-	}
-
-	if clusterCfg.MasterVipEnabled {
-		if clusterCfg.MasterVipInterface == "" {
-			return fmt.Errorf("MasterVipInterface cannot be empty when MasterVip is enabled")
-		}
-		if clusterCfg.MasterVipVrouterId < 1 || clusterCfg.MasterVipVrouterId > 255 {
-			return fmt.Errorf("MasterVipVrouterId should be in the range 1-255 when MasterVip is enabled")
-		}
 	}
 
 	// TODO: Need to validate if nodelet version in the bootstrap is the supported version, possibly by
@@ -155,9 +141,17 @@ func UpgradeCluster(cfgPath string) error {
 	if len(clusterCfg.MasterNodes) != len(masters) {
 		return fmt.Errorf("Masters in the cluster and Bootstrap config doesnt match", err)
 	}
+	newMasters, oldMasters, _ := getDiffNodes(clusterCfg.MasterNodes, masters)
+	if len(newMasters) != 0 || len(oldMasters) != 0 {
+		return fmt.Errorf("Masters in the cluster and Bootstrap config doesnt match")
+	}
 
 	if len(clusterCfg.WorkerNodes) != len(workers) {
 		return fmt.Errorf("Workers in the cluster and Bootstrap config doesnt match", err)
+	}
+	newWorkers, oldWorkers, _ := getDiffNodes(clusterCfg.WorkerNodes, workers)
+	if len(newWorkers) != 0 || len(oldWorkers) != 0 {
+		return fmt.Errorf("Workers in the cluster and Bootstrap config doesnt match")
 	}
 
 	// Upgrade each master node sequentially
@@ -192,12 +186,25 @@ func UpgradeCluster(cfgPath string) error {
 			deployer: deployer,
 		}
 
-		if err := deployer.UpgradeNode(); err != nil {
+		if err := deployer.UpgradeMaster(); err != nil {
 			SetClusterNodeStatus(deployer.clusterStatus, deployer.nodeletCfg.HostId, "failed", err)
 		}
 	}
 
-	// Upgrade each worker node sequentially
+	if err := UpgradeWorkers(clusterCfg, globalClusterStatus); err != nil {
+		zap.S().Infof("Failed to upgrade workers: %s", err)
+		return fmt.Errorf("Failed to upgrade workers: %s", err)
+	}
+
+	SyncNodes(clusterCfg, nil)
+
+	zap.S().Infof("Cluster Upgraded successfully")
+	return nil
+}
+
+func UpgradeWorkers(clusterCfg *BootstrapConfig, clusterStatus *ClusterStatus) error {
+	// Upgrade each worker node parallely
+	var wg sync.WaitGroup
 	for _, host := range clusterCfg.WorkerNodes {
 		zap.S().Infof("Upgrading worker: ", host.NodeName)
 		nodeletCfg := new(NodeletConfig)
@@ -209,27 +216,20 @@ func UpgradeCluster(cfgPath string) error {
 			zap.S().Infof("Failed to generate config: %s", err)
 			return fmt.Errorf("Failed to generate config: %s", err)
 		}
-		deployer, err := GetNodeletDeployer(clusterCfg, globalClusterStatus, nodeletCfg, host.NodeName, nodeletSrcFile)
+		deployer, err := GetNodeletDeployer(clusterCfg, clusterStatus, nodeletCfg, host.NodeName, nodeletSrcFile)
 		if err != nil {
 			zap.S().Errorf("failed to get nodelet deployer: %s", err)
 			return fmt.Errorf("failed to get nodelet deployer: %s", err)
 		}
-		globalClusterStatus.statusMap[host.NodeName] = &NodeStatus{
+		clusterStatus.statusMap[host.NodeName] = &NodeStatus{
 			deployer: deployer,
 		}
-
-		if err := deployer.UpgradeNode(); err != nil {
-			SetClusterNodeStatus(deployer.clusterStatus, deployer.nodeletCfg.HostId, "failed", err)
-		}
+		wg.Add(1)
+		go deployer.UpgradeWorker(&wg)
 	}
-
-	SyncNodes(clusterCfg, nil)
-
-	zap.S().Infof("Cluster Upgraded successfully")
+	wg.Wait()
 	return nil
 }
-
-
 func InitBootstrapConfig() *BootstrapConfig {
 	bootstrapCfg := &BootstrapConfig{
 		AllowWorkloadsOnMaster: false,
@@ -261,8 +261,8 @@ func ParseBootstrapConfig(cfgPath string) (*BootstrapConfig, error) {
 		return nil, fmt.Errorf("error decoding bootstrap config: %v", err)
 	}
 
-	if !isClusterCfgValid(bootstrapConfig) {
-		return nil, fmt.Errorf("Invalid cluster config")
+	if err := isClusterCfgValid(bootstrapConfig); err != nil {
+		return nil, fmt.Errorf("Invalid cluster config: %s", err)
 	}
 
 	return bootstrapConfig, nil
@@ -809,20 +809,25 @@ func SyncNodes(clusterCfg *BootstrapConfig, nodes *[]HostConfig) error {
 	return nil
 }
 
-func isClusterCfgValid(clusterCfg *BootstrapConfig) bool {
+func isClusterCfgValid(clusterCfg *BootstrapConfig) error {
 	if len(clusterCfg.MasterNodes) == 0 {
-		zap.S().Errorf("Number of master nodes cannot be zero")
-		return false
+		return fmt.Errorf("Number of master nodes cannot be zero")
 	}
 	if (len(clusterCfg.MasterNodes) % 2) == 0 {
-		zap.S().Errorf("Number of master nodes cannot be even")
-		return false
+		return fmt.Errorf("Number of master nodes cannot be even")
 	}
 	if !clusterCfg.AllowWorkloadsOnMaster && len(clusterCfg.WorkerNodes) == 0 {
-		zap.S().Errorf("Number of worker nodes cannot be zero when no workloads are allowed on masters")
-		return false
+		return fmt.Errorf("Number of worker nodes cannot be zero when no workloads are allowed on masters")
 	}
-	return true
+	if clusterCfg.MasterVipEnabled {
+		if clusterCfg.MasterVipInterface == "" {
+			return fmt.Errorf("MasterVipInterface cannot be empty when MasterVip is enabled")
+		}
+		if clusterCfg.MasterVipVrouterId < 1 || clusterCfg.MasterVipVrouterId > 255 {
+			return fmt.Errorf("MasterVipVrouterId should be in the range 1-255 when MasterVip is enabled")
+		}
+	}
+	return nil
 }
 
 func (cfg *BootstrapConfig) saveClusterConfig() error {

--- a/nodeletctl/pkg/nodeletctl/nodeletctl.go
+++ b/nodeletctl/pkg/nodeletctl/nodeletctl.go
@@ -106,6 +106,130 @@ func CreateCluster(cfgPath string) error {
 	return nil
 }
 
+func UpgradeCluster(cfgPath string) error {
+
+	clusterCfg, err := ParseBootstrapConfig(cfgPath)
+	if err != nil {
+		zap.S().Infof("Failed to Parse Cluster Config: %s", err)
+		return fmt.Errorf("Failed to Parse Cluster Config: %s", err)
+	}
+
+	if clusterCfg.MasterVipEnabled {
+		if clusterCfg.MasterVipInterface == "" {
+			return fmt.Errorf("MasterVipInterface cannot be empty when MasterVip is enabled")
+		}
+		if clusterCfg.MasterVipVrouterId < 1 || clusterCfg.MasterVipVrouterId > 255 {
+			return fmt.Errorf("MasterVipVrouterId should be in the range 1-255 when MasterVip is enabled")
+		}
+	}
+
+	// TODO: Need to validate if nodelet version in the bootstrap is the supported version, possibly by
+	// checking a manifest file in the rpm/deb package
+
+	if err != nil {
+		return fmt.Errorf("failed to DetermineKubePkgName: %s", err)
+	}
+
+	globalClusterStatus = new(ClusterStatus)
+	globalClusterStatus.statusMap = make(map[string]*NodeStatus)
+
+	var masterList = make(map[string]string)
+	for _, host := range clusterCfg.MasterNodes {
+		if host.NodeIP != nil {
+			masterList[host.NodeName] = *host.NodeIP
+		} else {
+			masterList[host.NodeName] = host.NodeName
+		}
+	}
+
+	masters, err := GetCurrentMasters(clusterCfg)
+	if err != nil {
+		return fmt.Errorf("Failed to get active K8s masters: %s", err)
+	}
+
+	workers, err := GetCurrentWorkers(clusterCfg)
+	if err != nil {
+		return fmt.Errorf("Failed to get active K8s workers: %s", err)
+	}
+
+	if len(clusterCfg.MasterNodes) != len(masters) {
+		return fmt.Errorf("Masters in the cluster and Bootstrap config doesnt match", err)
+	}
+
+	if len(clusterCfg.WorkerNodes) != len(workers) {
+		return fmt.Errorf("Workers in the cluster and Bootstrap config doesnt match", err)
+	}
+
+	// Upgrade each master node sequentially
+	for _, host := range clusterCfg.MasterNodes {
+		zap.S().Infof("Upgrading master node: ", host.NodeName)
+		// Build nodeletconfig and deployer
+		nodeletCfg := new(NodeletConfig)
+		setNodeletClusterCfg(clusterCfg, nodeletCfg)
+		nodeletCfg.HostId = host.NodeName
+		if host.NodeIP != nil {
+			nodeletCfg.HostIp = *host.NodeIP
+		} else {
+			nodeletCfg.HostIp = host.NodeName
+		}
+		nodeletCfg.NodeletRole = "master"
+		nodeletCfg.MasterList = &masterList
+		nodeletCfg.EtcdClusterState = "new"
+
+		nodeletSrcFile, err := GenNodeletConfigLocal(nodeletCfg, masterNodeletConfigTmpl)
+		if err != nil {
+			zap.S().Infof("Failed to generate config: %s", err)
+			return fmt.Errorf("Failed to generate config: %s", err)
+		}
+		zap.S().Debugf("master nodeletsrc file %s", nodeletSrcFile)
+
+		deployer, err := GetNodeletDeployer(clusterCfg, globalClusterStatus, nodeletCfg, nodeletCfg.HostIp, nodeletSrcFile)
+		if err != nil {
+			zap.S().Errorf("failed to get nodelet deployer: %v", err)
+			return fmt.Errorf("failed to get nodelet deployer: %v", err)
+		}
+		globalClusterStatus.statusMap[host.NodeName] = &NodeStatus{
+			deployer: deployer,
+		}
+
+		if err := deployer.UpgradeNode(); err != nil {
+			SetClusterNodeStatus(deployer.clusterStatus, deployer.nodeletCfg.HostId, "failed", err)
+		}
+	}
+
+	// Upgrade each worker node sequentially
+	for _, host := range clusterCfg.WorkerNodes {
+		zap.S().Infof("Upgrading worker: ", host.NodeName)
+		nodeletCfg := new(NodeletConfig)
+		setNodeletClusterCfg(clusterCfg, nodeletCfg)
+		nodeletCfg.HostId = host.NodeName
+		nodeletCfg.NodeletRole = "worker"
+		nodeletSrcFile, err := GenNodeletConfigLocal(nodeletCfg, workerNodeletConfigTmpl)
+		if err != nil {
+			zap.S().Infof("Failed to generate config: %s", err)
+			return fmt.Errorf("Failed to generate config: %s", err)
+		}
+		deployer, err := GetNodeletDeployer(clusterCfg, globalClusterStatus, nodeletCfg, host.NodeName, nodeletSrcFile)
+		if err != nil {
+			zap.S().Errorf("failed to get nodelet deployer: %s", err)
+			return fmt.Errorf("failed to get nodelet deployer: %s", err)
+		}
+		globalClusterStatus.statusMap[host.NodeName] = &NodeStatus{
+			deployer: deployer,
+		}
+
+		if err := deployer.UpgradeNode(); err != nil {
+			SetClusterNodeStatus(deployer.clusterStatus, deployer.nodeletCfg.HostId, "failed", err)
+		}
+	}
+
+	SyncNodes(clusterCfg, nil)
+
+	zap.S().Infof("Cluster Upgraded successfully")
+	return nil
+}
+
+
 func InitBootstrapConfig() *BootstrapConfig {
 	bootstrapCfg := &BootstrapConfig{
 		AllowWorkloadsOnMaster: false,
@@ -125,6 +249,7 @@ func InitBootstrapConfig() *BootstrapConfig {
 }
 
 func ParseBootstrapConfig(cfgPath string) (*BootstrapConfig, error) {
+	zap.S().Infof("ParseBootstrapConfig cfgPath: %s", cfgPath)
 	cfgFile, err := ioutil.ReadFile(cfgPath)
 	if err != nil {
 		return nil, fmt.Errorf("Error opening bootstrap config file: %s", cfgFile)
@@ -133,7 +258,7 @@ func ParseBootstrapConfig(cfgPath string) (*BootstrapConfig, error) {
 	bootstrapConfig := InitBootstrapConfig()
 	err = yaml.Unmarshal(cfgFile, bootstrapConfig)
 	if err != nil {
-		return nil, fmt.Errorf("Error decoding bootstrap config\n")
+		return nil, fmt.Errorf("error decoding bootstrap config: %v", err)
 	}
 
 	if !isClusterCfgValid(bootstrapConfig) {
@@ -210,7 +335,7 @@ func DeployCluster(clusterCfg *BootstrapConfig) error {
 	}
 
 	SyncNodes(clusterCfg, nil)
-
+	zap.S().Infof("Cluster deployed successfully")
 	return nil
 }
 
@@ -672,7 +797,7 @@ func SyncNodes(clusterCfg *BootstrapConfig, nodes *[]HostConfig) error {
 		for {
 			select {
 			case <-done:
-				zap.S().Infof("Cluster created succesfully\n")
+				zap.S().Infof("Cluster converged successfully\n")
 				return
 			case <-ticker.C:
 				zap.S().Infof("Syncing cluster state...\n")

--- a/nodeletctl/pkg/nodeletctl/nodeletctl.go
+++ b/nodeletctl/pkg/nodeletctl/nodeletctl.go
@@ -3,7 +3,6 @@ package nodeletctl
 import (
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"sync"
@@ -156,7 +155,7 @@ func UpgradeCluster(cfgPath string) error {
 
 	// Upgrade each master node sequentially
 	for _, host := range clusterCfg.MasterNodes {
-		zap.S().Infof("Upgrading master node: ", host.NodeName)
+		zap.S().Infof("Upgrading master node: %s", host.NodeName)
 		// Build nodeletconfig and deployer
 		nodeletCfg := new(NodeletConfig)
 		setNodeletClusterCfg(clusterCfg, nodeletCfg)
@@ -206,7 +205,7 @@ func UpgradeWorkers(clusterCfg *BootstrapConfig, clusterStatus *ClusterStatus) e
 	// Upgrade each worker node parallely
 	var wg sync.WaitGroup
 	for _, host := range clusterCfg.WorkerNodes {
-		zap.S().Infof("Upgrading worker: ", host.NodeName)
+		zap.S().Infof("Upgrading worker: %s", host.NodeName)
 		nodeletCfg := new(NodeletConfig)
 		setNodeletClusterCfg(clusterCfg, nodeletCfg)
 		nodeletCfg.HostId = host.NodeName


### PR DESCRIPTION
Does sequential upgrade of the management cluster, starting from master nodes and moving onto worker nodes.

Sequence of steps:
1. Determines nodelet package based on the OS type
2. Uninstalls Nodelet, Installs new nodelet package and restarts nodelet
3. Waits for the cluster to converge successfully

New package should be provided as part of bootstrap-config YAML as`nodeletPkg`. 
It also expects masterVipVrouterId and masterVipInterface to be configured when masterVipEnabled is true.

To run:
./airctl advanced-ddu upgrade-mgmt --bootstrap-config /root/ddu-cluster.yaml --verbose

Testing:
Tested with a single master and single worker with a workload deployment and upgrade worked fine.


