### PR TITLE
Fix nodelet packages with multiple files

### DIFF
--- a/nodeletctl/pkg/nodeletctl/deployer.go
+++ b/nodeletctl/pkg/nodeletctl/deployer.go
@@ -306,8 +306,7 @@ func (nd *NodeletDeployer) DetermineNodeletPkgName(nodeletPkgsDir string) (strin
 	if err != nil {
 		return "", fmt.Errorf("Failed to run : %s: %s: %s", lsNodeletCmd, err, stdErr)
 	}
-
-	nodeletPkgNames := strings.Split(string(stdOut), " ")
+	nodeletPkgNames := strings.Split(string(stdOut), "\n")
 	nodeletPkgName := ""
 	for _, pkgName := range nodeletPkgNames {
 		pkgName = strings.TrimSpace(pkgName)


### PR DESCRIPTION
ls command needed to be split with new line, to match the nodelet packages.


Testing:
Ran `./airctl advanced-ddu create-mgmt --bootstrap-config /root/ddu-cluster.yaml --verbose` with nodelet.tar.gz containing multiple package files and it seemed parse and match correctly. Cluster came up successfully.

Logs while testing:
2022-06-09T09:23:25.066Z	debug	Running command: ls /tmp/nodelet-pkgs/
2022-06-09T09:23:25.068Z	info	Matching pkg: nodelet-v0.2.5-12.x86_64.deb
2022-06-09T09:23:25.068Z	info	Matching pkg: nodelet-v0.2.5-12.x86_64.deb.md5
2022-06-09T09:23:25.068Z	info	Matching pkg: nodelet-v0.2.5-12.x86_64.rpm
2022-06-09T09:23:25.068Z	info	Match found for pkg: nodelet-v0.2.5-12.x86_64.rpm and os: centos
2022-06-09T09:23:25.068Z	debug	Running command: yum install -y /tmp/nodelet-pkgs/nodelet-v0.2.5-12.x86_64.rpm


2022-06-09T09:27:32.984Z	info	Syncing cluster state...

2022-06-09T09:27:32.984Z	info	Node 10.128.145.159 in state: ok

2022-06-09T09:27:32.984Z	info	Node 10.128.144.118 in state: ok

2022-06-09T09:27:32.984Z	info	Cluster converged successfully

2022-06-09T09:27:32.984Z	info	Cluster deployed successfully
2022-06-09T09:27:32.987Z	info	Wrote /etc/nodelet/airctl-mgmt/airctl-mgmt.yaml
Saved updated cluster spec to /etc/nodelet/airctl-mgmt/airctl-mgmt.yaml
Please save a copy for further cluster operations