### PR TITLE
Remove v from version name while tag names

### DIFF
--- a/get-version.bash
+++ b/get-version.bash
@@ -4,9 +4,9 @@
 # 2. Latest git tag using git describe --tags HEAD, if available
 # 3. Using branch name
 if [[ -n "${TAG_NAME}" ]]; then
-  TAG=$TAG_NAME
+  TAG=$( echo $TAG_NAME | sed 's/^v//')
 elif [[ $(git describe --tags HEAD > /dev/null 2>&1; echo $?) -eq 0 ]]; then
-  TAG=$(git describe --tags HEAD)
+  TAG=$(git describe --tags HEAD | sed 's/^v//')
   IFS='-'
   read -a strarr <<< "$TAG"
   TAG=${strarr[0]}


### PR DESCRIPTION

Ubuntu's deb and dpkg doesnt seem to like having v in the versioning, so removing them.

Error:
dpkg: error processing archive /tmp/apt-dpkg-install-I62IJJ/12-nodelet-v0.2.6-66987f9.x86_64.deb (--unpack):
 parsing file '/var/lib/dpkg/tmp.ci/control' near line 2 package 'pf9-kube':
 'Version' field value 'v0.2.6-66987f9': version number does not start with digit
Errors were encountered while processing:
 /tmp/apt-dpkg-install-I62IJJ/12-nodelet-v0.2.6-66987f9.x86_64.deb