### PR TITLE
AIR-432 Create pf9 user correctly for airgap ddu cluster creation using nodelet.

### DIFF
--- a/nodeletctl/pkg/nodeletctl/deployer.go
+++ b/nodeletctl/pkg/nodeletctl/deployer.go
@@ -286,15 +286,24 @@ func (nd *NodeletDeployer) CreatePf9User() error {
 		zap.S().Infof("User name already exist")
 		return nil
 	}
-	var cmdList []string
 	zap.S().Infof("Creating pf9 user")
-	cmdList = append(cmdList, "mkdir -p /opt/pf9/home")
-	cmdList = append(cmdList, "groupadd -f pf9group")
-	cmdList = append(cmdList, "id -u pf9 &>/dev/null || useradd -d /opt/pf9/home -G pf9group pf9")
 
-	for _, cmd := range cmdList {
-		if _, _, err := nd.client.RunCommand(cmd); err != nil {
-			return fmt.Errorf("createPf9User: %s: %s", cmd, err)
+	_, _, err = nd.client.RunCommand("mkdir -p /opt/pf9/home")
+	if err != nil {
+		return fmt.Errorf("failed to create home dir: %s", err)
+	}
+
+	_, _, err = nd.client.RunCommand("groupadd -f pf9group")
+	if err != nil {
+		return fmt.Errorf("failed to add pf9group: %s", err)
+	}
+
+	_, _, err = nd.client.RunCommand("id -u pf9")
+	if err != nil {
+		zap.S().Infof("check for id pf9: %s", err)
+		_, _, err = nd.client.RunCommand("useradd -d /opt/pf9/home -G pf9group pf9")
+		if err != nil {
+			return fmt.Errorf("createPf9User: %s", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
[AIR-432](https://platform9.atlassian.net/browse/AIR-432)

Nodelet cluster creation was failing to create pf9 user. Separated the commands to create the base cluster successfully now. 

```
[root@vedant-nodelet01 ~]# ./airctl advanced-ddu create-mgmt --bootstrap-config /root/nodelet.yaml --verbose
2022-07-27T08:48:39.071Z	debug	Logger started
2022-07-27T08:48:39.071Z	error	Failed to read config file: Config File "airctl-config" Not Found in "[/root]"
2022-07-27T08:48:39.071Z	info	ParseBootstrapConfig cfgPath: /root/nodelet.yaml
2022-07-27T08:48:39.072Z	info	Deploying cluster airctl-mgmt
2022-07-27T08:48:39.072Z	info	Certs exist, not generating new CA/key

2022-07-27T08:48:39.072Z	info	Certs already exist, using preexisting: /etc/nodelet/airctl-mgmt/certs

2022-07-27T08:48:41.885Z	info	Wrote kubeconfig to /etc/nodelet/airctl-mgmt/certs/admin.kubeconfig

2022-07-27T08:48:41.886Z	info	Deploying master node 10.128.144.30
2022-07-27T08:48:41.886Z	debug	master nodeletsrc file /etc/nodelet/airctl-mgmt/10.128.144.30/config_sunpike.yaml
2022-07-27T08:48:41.887Z	debug	Running command: cat /etc/os-release
2022-07-27T08:48:41.890Z	info	assuming OS type is CentOS, the os string is name="centos linux"
version="7 (core)"
id="centos"
id_like="rhel fedora"
version_id="7"
pretty_name="centos linux 7 (core)"
ansi_color="0;31"
cpe_name="cpe:/o:centos:centos:7"
home_url="https://www.centos.org/"
bug_report_url="https://bugs.centos.org/"

centos_mantisbt_project="centos-7"
centos_mantisbt_project_version="7"
redhat_support_product="centos"
redhat_support_product_version="7"


2022-07-27T08:48:41.890Z	info	Spawning master: 10.128.144.30
2022-07-27T08:48:41.891Z	info	Deploying nodelet: 10.128.144.30
2022-07-27T08:48:41.891Z	info	Checking pf9 user on node: 10.128.144.30
2022-07-27T08:48:41.891Z	debug	Running command: id -u pf9
2022-07-27T08:48:41.894Z	info	User name doesn't exist, proceeding to create
2022-07-27T08:48:41.894Z	info	Creating pf9 user
2022-07-27T08:48:41.894Z	debug	Running command: mkdir -p /opt/pf9/home
2022-07-27T08:48:41.897Z	debug	Running command: groupadd -f pf9group
2022-07-27T08:48:41.900Z	debug	Running command: id -u pf9
2022-07-27T08:48:41.902Z	info	check for id pf9: exit status 1
2022-07-27T08:48:41.902Z	debug	Running command: useradd -d /opt/pf9/home -G pf9group pf9
2022-07-27T08:48:41.950Z	info	Uploading certs to nodelet: 10.128.144.30
2022-07-27T08:48:41.950Z	info	Uploading /etc/nodelet/airctl-mgmt/certs/rootCA.crt to /etc/pf9/kube.d/
2022-07-27T08:48:41.950Z	debug	Running command: mkdir -p /etc/pf9/kube.d/
2022-07-27T08:48:41.952Z	debug	Running command: chown pf9 /etc/pf9/kube.d/ 
2022-07-27T08:48:41.953Z	debug	Uploading file /etc/nodelet/airctl-mgmt/certs/rootCA.crt to /tmp/rootCA.crt
2022-07-27T08:48:41.955Z	debug	Running command: mv /tmp/rootCA.crt /etc/pf9/kube.d/rootCA.crt
2022-07-27T08:48:41.957Z	info	Uploading /etc/nodelet/airctl-mgmt/certs/rootCA.key to /etc/pf9/kube.d/
2022-07-27T08:48:41.957Z	debug	Running command: mkdir -p /etc/pf9/kube.d/
2022-07-27T08:48:41.958Z	debug	Running command: chown pf9 /etc/pf9/kube.d/ 
2022-07-27T08:48:41.960Z	debug	Uploading file /etc/nodelet/airctl-mgmt/certs/rootCA.key to /tmp/rootCA.key
2022-07-27T08:48:41.960Z	debug	Running command: mv /tmp/rootCA.key /etc/pf9/kube.d/rootCA.key
2022-07-27T08:48:41.962Z	info	No offline container images specified, skipping upload...
2022-07-27T08:48:41.962Z	info	Copying nodelet config to node: 10.128.144.30
2022-07-27T08:48:41.962Z	info	Uploading /etc/nodelet/airctl-mgmt/10.128.144.30/config_sunpike.yaml to /etc/pf9/nodelet
2022-07-27T08:48:41.962Z	debug	Running command: mkdir -p /etc/pf9/nodelet
2022-07-27T08:48:41.963Z	debug	Running command: chown pf9 /etc/pf9/nodelet 
2022-07-27T08:48:41.965Z	debug	Uploading file /etc/nodelet/airctl-mgmt/10.128.144.30/config_sunpike.yaml to /tmp/config_sunpike.yaml
2022-07-27T08:48:41.965Z	debug	Running command: mv /tmp/config_sunpike.yaml /etc/pf9/nodelet/config_sunpike.yaml
2022-07-27T08:48:41.967Z	debug	Uploading file /opt/pf9/airctl/nodelet/nodelet.tar.gz to /tmp/nodelet.tar.gz
2022-07-27T08:48:42.895Z	debug	Running command: rm -Rf /tmp/nodelet-pkgs/
2022-07-27T08:48:42.976Z	debug	Running command: mkdir -p /tmp/nodelet-pkgs/
2022-07-27T08:48:42.979Z	debug	Running command: tar -C /tmp/nodelet-pkgs/ -xzvf /tmp/nodelet.tar.gz
2022-07-27T08:48:46.163Z	debug	Running command: ls /tmp/nodelet-pkgs/
2022-07-27T08:48:46.166Z	info	Matching pkg: nodelet-0.2.7-14.x86_64.deb
2022-07-27T08:48:46.166Z	info	Matching pkg: nodelet-0.2.7-14.x86_64.deb.md5
2022-07-27T08:48:46.166Z	info	Matching pkg: nodelet-0.2.7-14.x86_64.rpm
2022-07-27T08:48:46.166Z	info	Match found for pkg: nodelet-0.2.7-14.x86_64.rpm and os: centos
2022-07-27T08:48:46.167Z	debug	Running command: yum install -y /tmp/nodelet-pkgs/nodelet-0.2.7-14.x86_64.rpm
2022-07-27T08:49:01.515Z	info	Setting pf9 ownership
2022-07-27T08:49:01.516Z	debug	Running command: chown pf9:pf9group /var/log/pf9 
2022-07-27T08:49:01.522Z	debug	Running command: chown pf9:pf9group /var/opt/pf9 
2022-07-27T08:49:01.524Z	debug	Running command: chown pf9:pf9group /etc/pf9 
2022-07-27T08:49:01.526Z	debug	Running command: chown pf9:pf9group /opt/pf9 
2022-07-27T08:49:01.527Z	info	Starting nodelet
2022-07-27T08:49:01.528Z	debug	Running command: systemctl start pf9-nodeletd
2022-07-27T08:49:01.684Z	info	First master being spawned
2022-07-27T08:49:01.685Z	info	Refreshing nodelet status
2022-07-27T08:49:01.685Z	debug	Running command: cp /var/opt/pf9/kube_status /tmp/
2022-07-27T08:49:01.692Z	info	Done spawning master
2022-07-27T08:49:01.692Z	info	Master status: 

2022-07-27T08:49:01.692Z	info	err = RefreshNodeletStatus failed: exit status 1

2022-07-27T08:49:02.266Z	debug	connection successful
2022-07-27T08:49:02.334Z	info	assuming OS type is CentOS, the os string is name="centos linux"
version="7 (core)"
id="centos"
id_like="rhel fedora"
version_id="7"
pretty_name="centos linux 7 (core)"
ansi_color="0;31"
cpe_name="cpe:/o:centos:centos:7"
home_url="https://www.centos.org/"
bug_report_url="https://bugs.centos.org/"

centos_mantisbt_project="centos-7"
centos_mantisbt_project_version="7"
redhat_support_product="centos"
redhat_support_product_version="7"


2022-07-27T08:49:02.334Z	info	Adding worker 10.128.144.202 to cluster airctl-mgmt
2022-07-27T08:49:02.334Z	info	Spawning worker: 10.128.144.202
2022-07-27T08:49:02.334Z	info	Deploying nodelet: 10.128.144.202
2022-07-27T08:49:02.334Z	info	Checking pf9 user on node: 10.128.144.202
2022-07-27T08:49:02.397Z	info	User name already exist
2022-07-27T08:49:02.397Z	info	Uploading certs to nodelet: 10.128.144.202
2022-07-27T08:49:02.397Z	info	Uploading /etc/nodelet/airctl-mgmt/certs/rootCA.crt to /etc/pf9/kube.d/
2022-07-27T08:49:02.603Z	info	Uploading /etc/nodelet/airctl-mgmt/certs/rootCA.key to /etc/pf9/kube.d/
2022-07-27T08:49:02.817Z	info	No offline container images specified, skipping upload...
2022-07-27T08:49:02.817Z	info	Copying nodelet config to node: 10.128.144.202
2022-07-27T08:49:02.817Z	info	Uploading /etc/nodelet/airctl-mgmt/10.128.144.202/config_sunpike.yaml to /etc/pf9/nodelet
2022-07-27T08:49:20.492Z	info	Matching pkg: nodelet-0.2.7-14.x86_64.deb
2022-07-27T08:49:20.493Z	info	Matching pkg: nodelet-0.2.7-14.x86_64.deb.md5
2022-07-27T08:49:20.493Z	info	Matching pkg: nodelet-0.2.7-14.x86_64.rpm
2022-07-27T08:49:20.493Z	info	Match found for pkg: nodelet-0.2.7-14.x86_64.rpm and os: centos
2022-07-27T08:49:38.561Z	info	Setting pf9 ownership
2022-07-27T08:49:38.855Z	info	Starting nodelet
2022-07-27T08:49:39.030Z	info	Refreshing nodelet status
2022-07-27T08:49:39.101Z	debug	Error 	{"stdout": "", "stderr": "cp: cannot stat ‘/var/opt/pf9/kube_status’: No such file or directory\n"}
2022-07-27T08:49:39.101Z	info	Done spawning worker: 10.128.144.202

2022-07-27T08:49:39.701Z	debug	connection successful
2022-07-27T08:49:39.783Z	info	assuming OS type is CentOS, the os string is name="centos linux"
version="7 (core)"
id="centos"
id_like="rhel fedora"
version_id="7"
pretty_name="centos linux 7 (core)"
ansi_color="0;31"
cpe_name="cpe:/o:centos:centos:7"
home_url="https://www.centos.org/"
bug_report_url="https://bugs.centos.org/"

centos_mantisbt_project="centos-7"
centos_mantisbt_project_version="7"
redhat_support_product="centos"
redhat_support_product_version="7"


2022-07-27T08:49:39.783Z	info	Fetching status for node 10.128.144.202
2022-07-27T08:49:39.783Z	info	Refreshing nodelet status
2022-07-27T08:49:39.856Z	debug	Running command: cat /etc/os-release
2022-07-27T08:49:39.861Z	info	assuming OS type is CentOS, the os string is name="centos linux"
version="7 (core)"
id="centos"
id_like="rhel fedora"
version_id="7"
pretty_name="centos linux 7 (core)"
ansi_color="0;31"
cpe_name="cpe:/o:centos:centos:7"
home_url="https://www.centos.org/"
bug_report_url="https://bugs.centos.org/"

centos_mantisbt_project="centos-7"
centos_mantisbt_project_version="7"
redhat_support_product="centos"
redhat_support_product_version="7"


2022-07-27T08:49:39.861Z	info	Fetching status for node 10.128.144.30
2022-07-27T08:49:39.861Z	info	Refreshing nodelet status
2022-07-27T08:49:39.861Z	debug	Running command: cp /var/opt/pf9/kube_status /tmp/
2022-07-27T08:49:39.865Z	debug	Downloading file /var/opt/pf9/kube_status to /etc/nodelet/airctl-mgmt/10.128.144.30/kube_status.json
2022-07-27T08:50:09.866Z	info	Syncing cluster state...

2022-07-27T08:50:09.867Z	info	Node 10.128.144.202 in state: converging

2022-07-27T08:50:09.867Z	info	Refreshing nodelet status
2022-07-27T08:50:09.992Z	info	Node 10.128.144.30 in state: converging

2022-07-27T08:50:09.992Z	info	Refreshing nodelet status
2022-07-27T08:50:09.992Z	debug	Running command: cp /var/opt/pf9/kube_status /tmp/
2022-07-27T08:50:09.999Z	debug	Downloading file /var/opt/pf9/kube_status to /etc/nodelet/airctl-mgmt/10.128.144.30/kube_status.json
2022-07-27T08:50:10.000Z	info	Nodes are not synced, will re-check...

2022-07-27T08:50:39.873Z	info	Syncing cluster state...

2022-07-27T08:50:39.874Z	info	Node 10.128.144.202 in state: converging

2022-07-27T08:50:39.874Z	info	Refreshing nodelet status
2022-07-27T08:50:39.963Z	info	Node 10.128.144.30 in state: converging

2022-07-27T08:50:39.963Z	info	Refreshing nodelet status
2022-07-27T08:50:39.963Z	debug	Running command: cp /var/opt/pf9/kube_status /tmp/
2022-07-27T08:50:39.970Z	debug	Downloading file /var/opt/pf9/kube_status to /etc/nodelet/airctl-mgmt/10.128.144.30/kube_status.json
2022-07-27T08:50:39.971Z	info	Nodes are not synced, will re-check...

2022-07-27T08:51:09.866Z	info	Syncing cluster state...

2022-07-27T08:51:09.866Z	info	Node 10.128.144.202 in state: converging

2022-07-27T08:51:09.867Z	info	Refreshing nodelet status
2022-07-27T08:51:09.962Z	info	Node 10.128.144.30 in state: converging

2022-07-27T08:51:09.962Z	info	Refreshing nodelet status
2022-07-27T08:51:09.962Z	debug	Running command: cp /var/opt/pf9/kube_status /tmp/
2022-07-27T08:51:09.974Z	debug	Downloading file /var/opt/pf9/kube_status to /etc/nodelet/airctl-mgmt/10.128.144.30/kube_status.json
2022-07-27T08:51:09.977Z	info	Nodes are not synced, will re-check...

2022-07-27T08:51:39.866Z	info	Syncing cluster state...

2022-07-27T08:51:39.866Z	info	Node 10.128.144.202 in state: ok

2022-07-27T08:51:39.866Z	info	Node 10.128.144.30 in state: ok

2022-07-27T08:51:39.866Z	info	Cluster converged successfully

2022-07-27T08:51:39.866Z	info	Cluster deployed successfully
2022-07-27T08:51:39.868Z	info	Wrote /etc/nodelet/airctl-mgmt/airctl-mgmt.yaml
Saved updated cluster spec to /etc/nodelet/airctl-mgmt/airctl-mgmt.yaml
Please save a copy for further cluster operations

[root@vedant-nodelet01 ~]# ls -alh /opt/pf9/home
total 0
drwxr-xr-x. 2 root root      6 Jul 27 08:48 .
drwxr-xr-x. 6 pf9  pf9group 92 Jul 27 08:48 ..
```