### PR TITLE
Templatize CoreDNS hosts from /etc/hosts or user hosts file

### DIFF
--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/conf/networkapps/coredns.yaml
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/conf/networkapps/coredns.yaml
@@ -78,6 +78,12 @@ data:
         loop
         reload
         loadbalance
+        {{ if .DnsEntries -}} hosts {
+        {{- range $ip, $hostname := .DnsEntries}}
+            {{ $ip }} {{ $hostname -}}
+        {{end}}
+            fallthrough
+        {{end -}}
     }
 ---
 apiVersion: apps/v1

--- a/nodelet/pkg/utils/config/config.go
+++ b/nodelet/pkg/utils/config/config.go
@@ -44,6 +44,7 @@ var DefaultConfig = Config{
 	GRPCRetryTimeoutSeconds: 5,
 	NumCmdOutputLinesToLog:  10, // 0 indicates no command lines to be logged
 	UserImagesDir:           constants.UserImagesDir,
+	CoreDNSHostsFile:        "/etc/hosts",
 }
 
 // Config a struct to load the values from viper for future use.
@@ -86,6 +87,7 @@ type Config struct {
 	ServicesCIDR              string  `mapstructure:"SERVICES_CIDR"`
 	AppCatalogEnabled         bool    `mapstructure:"APP_CATALOG_ENABLED"`
 	KubeletCloudConfig        string  `mapstructure:"KUBELET_CLOUD_CONFIG"`
+	CoreDNSHostsFile          string  `mapstructure:"COREDNS_HOSTS_FILE"`
 }
 
 // ToStringMap converts the Config struct to a map of strings

--- a/nodelet/pkg/utils/constants/constants.go
+++ b/nodelet/pkg/utils/constants/constants.go
@@ -124,7 +124,8 @@ var (
 	// CoreDNSTemplate is template file for coredns
 	CoreDNSTemplate = fmt.Sprintf("%s/networkapps/coredns.yaml", ConfigSrcDir)
 	// CoreDNSFile is applied coredns file
-	CoreDNSFile = fmt.Sprintf("%s/networkapps/coredns-applied.yaml", ConfigSrcDir)
+	CoreDNSFile      = fmt.Sprintf("%s/networkapps/coredns-applied.yaml", ConfigSrcDir)
+	CoreDNSHostsFile = "/etc/hosts"
 
 	CloudConfigFile = "/etc/pf9/kube.d/cloud-config"
 

--- a/nodelet/pkg/utils/container_runtime/image_utils.go
+++ b/nodelet/pkg/utils/container_runtime/image_utils.go
@@ -15,6 +15,7 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/pkg/errors"
 	"github.com/platform9/nodelet/nodelet/pkg/utils/constants"
+	"go.uber.org/zap"
 )
 
 type ImageUtility struct{}
@@ -43,7 +44,7 @@ func (i *ImageUtility) LoadImagesFromDir(ctx context.Context, imageDir string, n
 
 // LoadImagesFromFile loads images from given tar file to container runtime
 func (i *ImageUtility) LoadImagesFromFile(ctx context.Context, fileName string) error {
-
+	zap.S().Infof("Loading images from file: %s", fileName)
 	f, err := os.Open(fileName)
 	if err != nil {
 		return err
@@ -52,7 +53,6 @@ func (i *ImageUtility) LoadImagesFromFile(ctx context.Context, fileName string) 
 	if err != nil {
 		return err
 	}
-
 	platform := platforms.DefaultStrict()
 
 	client, err := containerd.New(constants.ContainerdSocket, containerd.WithDefaultPlatform(platform))
@@ -66,6 +66,7 @@ func (i *ImageUtility) LoadImagesFromFile(ctx context.Context, fileName string) 
 	}
 	for _, img := range imgs {
 		image := containerd.NewImageWithPlatform(client, img, platform)
+		zap.S().Infof("Unpacking image: %s", image.Name())
 		err = image.Unpack(ctx, constants.DefaultSnapShotter)
 		if err != nil {
 			return errors.Wrapf(err, "failed to unpack image: %s", image.Name())

--- a/nodeletctl/pkg/nodeletctl/deployer.go
+++ b/nodeletctl/pkg/nodeletctl/deployer.go
@@ -206,6 +206,9 @@ func (nd *NodeletDeployer) DeployNodelet() error {
 	if err := nd.UploadUserImages(); err != nil {
 		return fmt.Errorf("failed to upload user container images: %s", err)
 	}
+	if err := nd.UploadCoreDNSHostsFile(); err != nil {
+		return fmt.Errorf("failed to upload custom coreDNS hosts file: %s", err)
+	}
 	if err := nd.CopyNodeletConfig(); err != nil {
 		return fmt.Errorf("failed to copy nodelet config: %s", err)
 	}
@@ -595,6 +598,19 @@ func (nd *NodeletDeployer) UploadUserImages() error {
 		if err != nil {
 			return fmt.Errorf("Failed to upload user images: %s", err)
 		}
+	}
+	return nil
+}
+
+func (nd *NodeletDeployer) UploadCoreDNSHostsFile() error {
+	if nd.nodeletCfg.CoreDNSHostsFile != "" {
+		zap.S().Infof("No custom hosts file specified, skipping upload")
+		return nil
+	}
+
+	err := UploadFileWrapper(nd.nodeletCfg.CoreDNSHostsFile, "hosts", "/etc/pf9/", nd.client)
+	if err != nil {
+		return fmt.Errorf("Failed to upload custom hosts file: %s", err)
 	}
 	return nil
 }

--- a/nodeletctl/pkg/nodeletctl/templates.go
+++ b/nodeletctl/pkg/nodeletctl/templates.go
@@ -103,6 +103,11 @@ STANDALONE: "true"
 DOCKER_ROOT: /var/lib/docker
 {{if .UserImages -}}
 USER_IMAGES_DIR: "/var/opt/pf9/images"
+{{ end -}}
+{{ if .CoreDNSHostsFile -}}
+COREDNS_HOSTS_FILE: "/etc/pf9/hosts"
+{{ else -}
+COREDNS_HOSTS_FILE = "/etc/hosts"
 {{ end }}
 `
 
@@ -184,6 +189,11 @@ STANDALONE: "true"
 DOCKER_ROOT: /var/lib/docker
 {{if .UserImages -}}
 USER_IMAGES_DIR: "/var/opt/pf9/images"
+{{ end -}}
+{{ if .CoreDNSHostsFile -}}
+COREDNS_HOSTS_FILE: "/etc/pf9/hosts"
+{{ else -}
+COREDNS_HOSTS_FILE = "/etc/hosts"
 {{ end }}
 `
 const adminKubeconfigTemplate = `


### PR DESCRIPTION
We need this to publish the dufqdn in coreDNS. For SaaS, it is publishde in route53 but we dont have that in airgap, so we have to add static DNS entries in CoreDNS.

nodeletctl config now takes in a new DNS section with tag dns:

```type CoreDNSConfig struct {
	HostsFile   string   `json:"hostsFile,omitempty"`
	InlineHosts []string `json:"corednsHosts,omitempty"`
}
```
I have not implemented inline hosts yet. Airctl will be generating the hosts file from it's own config and specifying that