### PR TITLE
AIR-534: Enabling default kube certificate signer in controller-manager

### DIFF
--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/conf/masterconfig/base/centos/master.yaml
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/conf/masterconfig/base/centos/master.yaml
@@ -12,8 +12,6 @@ spec:
       command:
         - "kube-controller-manager"
         - "--cloud-provider=__CLOUD_PROVIDER__"
-        - "--cluster-signing-cert-file=/srv/kubernetes/certs/apiserver/request.crt"
-        - "--cluster-signing-key-file=/srv/kubernetes/certs/apiserver/request.key"
         - "--kubeconfig=/srv/kubernetes/kubeconfigs/kube-controller-manager.yaml"
         - "--leader-elect=true"
         - "--profiling=false"

--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/conf/masterconfig/base/centos/master.yaml
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/conf/masterconfig/base/centos/master.yaml
@@ -12,6 +12,8 @@ spec:
       command:
         - "kube-controller-manager"
         - "--cloud-provider=__CLOUD_PROVIDER__"
+        - "--cluster-signing-cert-file=/srv/kubernetes/certs/apiserver/request.crt"
+        - "--cluster-signing-key-file=/srv/kubernetes/certs/apiserver/request.key"
         - "--kubeconfig=/srv/kubernetes/kubeconfigs/kube-controller-manager.yaml"
         - "--leader-elect=true"
         - "--profiling=false"

--- a/nodeletctl/pkg/nodeletctl/templates.go
+++ b/nodeletctl/pkg/nodeletctl/templates.go
@@ -22,7 +22,7 @@ CLOUD_PROVIDER_TYPE: local
 CLUSTER_ID: {{ .ClusterId }}
 CLUSTER_PROJECT_ID: 373d078433b8422490fdfcd96d406805
 CONTAINERS_CIDR: 10.20.0.0/22
-CONTROLLER_MANAGER_FLAGS: ""
+CONTROLLER_MANAGER_FLAGS: "--cluster-signing-cert-file=/srv/kubernetes/certs/apiserver/request.crt,--cluster-signing-key-file=/srv/kubernetes/certs/apiserver/request.key"
 CPU_MANAGER_POLICY: none
 DEBUG: "true"
 DEPLOY_KUBEVIRT: "false"


### PR DESCRIPTION
This is needed by minio operator because it relies on kube-controller-manager's default certificate manager to get certificates signed. 
Reference: https://min.io/docs/minio/kubernetes/upstream/operations/installation.html#kubernetes-tls-certificate-api

Testing:
Deployed these changes onto a cluster, and installed minio. I was able to access minio from minio client using the service DNS name with `--insecure` flag.
