### PR TITLE
AIR-539 Remove unpack and snapshot of image; disable eviction threshold

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ cni-plugins: $(CNI_PLUGINS_DIR)
 # NERDCTL install
 .PHONY: nerdctl
 NERDCTL_CLI := "nerdctl"
-NERDCTL_CLI_VERSION := "0.10.0"
+NERDCTL_CLI_VERSION := "0.22.0"
 NERDCTL_URL := https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_CLI_VERSION}/nerdctl-${NERDCTL_CLI_VERSION}-linux-amd64.tar.gz
 NERDCTL_DIR := "nerdctl"
 

--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/utils.sh
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/utils.sh
@@ -453,6 +453,14 @@ staticPodPath: "${STATIC_POD_PATH}"
 tlsCertFile: "${TLS_CERT_FILE}"
 tlsPrivateKeyFile: "${TLS_PRIVATE_KEY_FILE}"
 tlsCipherSuites: ${TLS_CIPHER_SUITES}
+imageMinimumGCAge: 24h
+imageGCHighThresholdPercent: 99
+imageGCLowThresholdPercent: 95
+evictionHard:
+  nodefs.available: "0%"
+  nodefs.inodesFree: "0%"
+  imagefs.available: "0%"
+  imagefs.inodesFree: "0%"
 EOF
 
     if [ "$CONTAINERD_CGROUP" = "systemd" ]; then


### PR DESCRIPTION
Can we get this in for now. Will make it configureable via nodeletctl later - flag to disable (0%) these thresholds or leave unset (defaults).

Also the unpack and snapshot seems uncessary and doubles disk space. the Container runtime or kubelet seems to cunpack and snapshot before creating a new container, so it is not needed to do by us. downside being a container may be slower to spawn? timeouts?
but upside being import images phase is a little faster now