### PR TITLE
AIR-547: Install keepalived v2.1.3 from phases scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -554,7 +554,7 @@ $(PF9_KUBE_DEB_FILE): $(DEB_SRC_ROOT)
 		--description "Platform9 kubernetes(Nodelet) deb package. Built on git hash $(GITHASH)" \
 		-v $(PF9_KUBE_VERSION)-$(PF9_KUBE_RELEASE) --provides nodelet --provides pf9app \
 		--license "Commercial" --architecture all --url "http://www.platform9.net" --vendor Platform9 \
-		-d curl -d gzip -d net-tools -d socat -d keepalived -d cgroup-tools \
+		-d curl -d gzip -d net-tools -d keepalived -d cgroup-tools \
 		--after-install $(AGENT_SRC_DIR)/pf9-kube-after-install.sh \
 		--before-remove $(AGENT_SRC_DIR)/pf9-kube-before-remove.sh \
 		--after-remove ${AGENT_SRC_DIR}/pf9-kube-after-remove.sh \

--- a/Makefile
+++ b/Makefile
@@ -315,6 +315,22 @@ nerdctl:
     curl --output ${NERDCTL_DIR}/nerdctl-${NERDCTL_CLI_VERSION}-linux-amd64.tar.gz -L ${NERDCTL_URL} && \
     tar -C ${NERDCTL_DIR} -xvf ${NERDCTL_DIR}/nerdctl-${NERDCTL_CLI_VERSION}-linux-amd64.tar.gz
 
+# Keealived packages download
+.PHONY: keepalived
+KEEPALIVED_DEB_U20 := https://github.com/hnakamur/keepalived-deb/releases/download/debian%2F1%252.1.3-1ubuntu1ppa1-focal/keepalived_2.1.3-1ubuntu1ppa1.focal_amd64.deb
+KEEPALIVED_DEB_U18 := https://github.com/hnakamur/keepalived-deb/releases/download/debian%2F1%252.1.3-1ubuntu1ppa1-bionic/keepalived_2.1.3-1ubuntu1ppa1.bionic_amd64.deb
+KEEPALIVED_RPM_CENTOS7 := https://github.com/hnakamur/keepalived-rpm/releases/download/2.1.3-1/keepalived-2.1.3-1.el7.x86_64.rpm
+
+keepalived:
+	echo "Downloading Keepalived packages"
+	mkdir -p $(COMMON_SRC_ROOT)${KUBERNETES_EXECUTABLES}/keepalived_packages/
+	curl --output $(COMMON_SRC_ROOT)${KUBERNETES_EXECUTABLES}/keepalived_packages/keepalived_2.1.3-1ubuntu1ppa1.focal_amd64.deb -L ${KEEPALIVED_DEB_U20}
+	curl --output $(COMMON_SRC_ROOT)${KUBERNETES_EXECUTABLES}/keepalived_packages/keepalived_2.1.3-1ubuntu1ppa1.bionic_amd64.deb -L ${KEEPALIVED_DEB_U18}
+	curl --output $(COMMON_SRC_ROOT)${KUBERNETES_EXECUTABLES}/keepalived_packages/keepalived-2.1.3-1.el7.x86_64.rpm -L ${KEEPALIVED_RPM_CENTOS7}
+	# Download Ubuntu 18.04 dependency packages as well
+	curl --output $(COMMON_SRC_ROOT)${KUBERNETES_EXECUTABLES}/keepalived_packages/libjansson4_2.11-1_amd64.deb -L http://archive.ubuntu.com/ubuntu/pool/main/j/jansson/libjansson4_2.11-1_amd64.deb
+	curl --output $(COMMON_SRC_ROOT)${KUBERNETES_EXECUTABLES}/keepalived_packages/libnftnl7_1.0.9-2_amd64.deb -L http://archive.ubuntu.com/ubuntu/pool/universe/libn/libnftnl/libnftnl7_1.0.9-2_amd64.deb
+
 
 # CRICTL install
 .PHONY: crictl
@@ -478,7 +494,7 @@ jq:
 	${WGET_CMD} -O jq -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
 	chmod u=rwx,og=rx jq
 
-$(COMMON_SRC_ROOT): easyrsa $(AUTHBS_SRC_DIR) bouncer-docker-image kubernetes nodelet cni-plugins nerdctl crictl calicoctl etcdctl etcd_raft_checker pf9kube-addr-conv pf9kube-ip_type virtctl jq
+$(COMMON_SRC_ROOT): easyrsa $(AUTHBS_SRC_DIR) bouncer-docker-image kubernetes nodelet cni-plugins nerdctl crictl calicoctl etcdctl etcd_raft_checker pf9kube-addr-conv pf9kube-ip_type virtctl jq keepalived
 	echo "make COMMON_SRC_ROOT $(COMMON_SRC_ROOT)"
 	echo "COMMON_SRC_ROOT is $(COMMON_SRC_ROOT)" # i.e. /vagrant/build/pf9-kube/pf9-kube-src/common
 	echo "AGENT_SRC_DIR is $(AGENT_SRC_DIR)" # cp -a /vagrant/agent/root/* /vagrant/build/pf9-kube/pf9-kube-src/common/
@@ -554,7 +570,7 @@ $(PF9_KUBE_DEB_FILE): $(DEB_SRC_ROOT)
 		--description "Platform9 kubernetes(Nodelet) deb package. Built on git hash $(GITHASH)" \
 		-v $(PF9_KUBE_VERSION)-$(PF9_KUBE_RELEASE) --provides nodelet --provides pf9app \
 		--license "Commercial" --architecture all --url "http://www.platform9.net" --vendor Platform9 \
-		-d curl -d gzip -d net-tools -d keepalived -d cgroup-tools \
+		-d curl -d gzip -d net-tools -d cgroup-tools \
 		--after-install $(AGENT_SRC_DIR)/pf9-kube-after-install.sh \
 		--before-remove $(AGENT_SRC_DIR)/pf9-kube-before-remove.sh \
 		--after-remove ${AGENT_SRC_DIR}/pf9-kube-after-remove.sh \

--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/defaults.env
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/defaults.env
@@ -100,6 +100,7 @@ ETCD_VERSION=3.4.14
 ETCD_CONTAINER_IMG="gcr.io/etcd-development/etcd:v${ETCD_VERSION}"
 
 # KEEPALIVED config directory
+KEEPALIVED_VERSION="v2.1.3"
 MASTER_VIP_KEEPALIVED_CONF_FILE="/etc/keepalived/keepalived.conf"
 
 #VRRP configs

--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/os_centos.sh
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/os_centos.sh
@@ -392,3 +392,14 @@ EOF
     systemctl daemon-reload
     systemctl restart containerd
 }
+
+function install_keepalived()
+{
+  echo "Removing keepalived"
+  # remove keepalived
+  yum erase -y keepalived
+
+  echo "Installing keepalived"
+  # install keepalived
+  yum install -y $KEEPALIVED_PACKAGE_DIR/keepalived-2.1.3-1.el7.x86_64.rpm
+}

--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/os_ubuntu.sh
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/os_ubuntu.sh
@@ -270,3 +270,23 @@ EOF
     systemctl daemon-reload
     systemctl restart containerd
 }
+
+function install_keepalived()
+{
+  # remove keepalived
+  echo "Removing keepalived"
+  apt-get purge -y keepalived
+
+  # install keepalived
+  echo "Installing keepalived"
+  if [ $VERSION_ID == "18.04" ]; then
+    echo "Installing libjansson4_2.11-1_amd64.deb, libnftnl7_1.0.9-2_amd64.deb and keepalived 2.1.3"
+    apt-get install -y $KEEPALIVED_PACKAGE_DIR/libjansson4_2.11-1_amd64.deb $KEEPALIVED_PACKAGE_DIR/libnftnl7_1.0.9-2_amd64.deb $KEEPALIVED_PACKAGE_DIR/keepalived_2.1.3-1ubuntu1ppa1.bionic_amd64.deb
+  elif [ $VERSION_ID == "20.04" ]; then
+    echo "Installing keepalived_2.1.3-1ubuntu1ppa1.focal_amd64.deb"
+    apt-get install -y $KEEPALIVED_PACKAGE_DIR/keepalived_2.1.3-1ubuntu1ppa1.focal_amd64.deb
+  else
+    echo "Unsupported OS version for keepalived"
+  fi
+
+}

--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/phases/configure_start_keepalived.sh
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/phases/configure_start_keepalived.sh
@@ -13,6 +13,7 @@ source master_utils.sh
 
 function start() {
     if [ "${MASTER_VIP_ENABLED}" == "true" ]; then
+        ensure_keepalived_installed
         ensure_keepalived_configured
         start_keepalived
     fi
@@ -26,6 +27,13 @@ function stop() {
 
 function status() {
     if [ "${MASTER_VIP_ENABLED}" == "true" ]; then
+        # Check if correct version of keepalived installed
+        IS_KEEPALIVED_INSTALLED=-1
+        check_keepalived_installed
+        if [ $IS_KEEPALIVED_INSTALLED == 0 ]; then
+          exit 1
+        fi
+        # check if keepalived is running
         keepalived_running
     fi
 }

--- a/pf9-kube.spec
+++ b/pf9-kube.spec
@@ -9,7 +9,6 @@ Provides:       pf9app
 Requires:       curl
 Requires:       gzip
 Requires:       net-tools
-Requires:       keepalived
 Requires:       libcgroup-tools
 AutoReqProv:    no
 

--- a/pf9-kube.spec
+++ b/pf9-kube.spec
@@ -9,7 +9,6 @@ Provides:       pf9app
 Requires:       curl
 Requires:       gzip
 Requires:       net-tools
-Requires:       socat
 Requires:       keepalived
 Requires:       libcgroup-tools
 AutoReqProv:    no


### PR DESCRIPTION
Porting this over from pf9-kube: https://github.com/platform9/pf9-kube/commit/e0e8a079d787010b81fb8d57f6e05aeb5c1ac336

Needed for airgap. Also removing socat, I dont see it being used anywhere