### PR TITLE
Fix socket leak

### DIFF
--- a/nodelet/pkg/utils/kubeutils/kube_utils.go
+++ b/nodelet/pkg/utils/kubeutils/kube_utils.go
@@ -308,6 +308,11 @@ func (u *UtilsImpl) K8sApiAvailable(cfg config.Config) error {
 	}
 
 	res, err := client.Get(healthzUrl)
+
+	defer func() {
+		res.Body.Close()
+	}()
+
 	if err != nil {
 		return errors.Wrap(err, "could not get to healthz")
 	}
@@ -435,7 +440,6 @@ func (u *UtilsImpl) EnsureAppCatalog() error {
 
 // ApplyYamlConfigFiles applies the yaml files
 func (u *UtilsImpl) ApplyYamlConfigFiles(files []string) error {
-
 	flags := genericclioptions.NewConfigFlags(false)
 	flags.KubeConfig = &constants.KubeConfig
 	cfg := kube.NewConfig(flags)


### PR DESCRIPTION
This commit fixes a socket leak that would cause nodelet to use more than 1000 file descriptors over 24-30 hours.

Testing done:
Copy the modified binary to a host and restart nodelet. Monitored the file descriptor usage over couple of hours. 