### PR TITLE
AIR-557: adding nodelet Root CA as trusted certs

### DIFF
--- a/nodeletctl/pkg/nodeletctl/consts.go
+++ b/nodeletctl/pkg/nodeletctl/consts.go
@@ -25,4 +25,5 @@ const (
 	WorkerLabel        = "node-role.kubernetes.io/worker"
 	MasterLabel        = "node-role.kubernetes.io/master"
 	UserImagesDir      = "/var/opt/pf9/images"
+	CAPath             = "/etc/pki/ca-trust/source/anchors/nodelet-ca.pem"
 )

--- a/nodeletctl/pkg/nodeletctl/nodeletctl.go
+++ b/nodeletctl/pkg/nodeletctl/nodeletctl.go
@@ -308,8 +308,8 @@ func DeployCluster(clusterCfg *BootstrapConfig) error {
 
 	err := trustCA(clusterCfg.CertsDir)
 	if err != nil {
-		zap.S().Infof("error adding nodelet Root CA as trusted certs: %s\n", err)
-		return err
+		zap.S().Errorf("error adding nodelet Root CA as trusted certs: %s\n", err)
+		return fmt.Errorf("error adding nodelet Root CA as trusted certs: %s\n", err)
 	}
 
 	if err := GenKubeconfig(clusterCfg); err != nil {
@@ -772,6 +772,12 @@ func RegenClusterCerts(cfgPath string) error {
 	if err != nil {
 		zap.S().Errorf("Failed to regenerate new CA: %s", err)
 		return fmt.Errorf("Failed to regenerate new CA: %s", err)
+	}
+
+	err = trustCA(clusterCfg.CertsDir)
+	if err != nil {
+		zap.S().Errorf("error adding nodelet Root CA as trusted certs: %s\n", err)
+		return fmt.Errorf("error adding nodelet Root CA as trusted certs: %s\n", err)
 	}
 
 	clusterStatus := new(ClusterStatus)

--- a/nodeletctl/pkg/nodeletctl/nodeletctl.go
+++ b/nodeletctl/pkg/nodeletctl/nodeletctl.go
@@ -306,6 +306,12 @@ func DeployCluster(clusterCfg *BootstrapConfig) error {
 		clusterCfg.CertsDir = certsDir
 	}
 
+	err := trustCA(clusterCfg.CertsDir)
+	if err != nil {
+		zap.S().Infof("error adding nodelet Root CA as trusted certs: %s\n", err)
+		return err
+	}
+
 	if err := GenKubeconfig(clusterCfg); err != nil {
 		zap.S().Infof("Failed to generate kubeconfig: %s\n", err)
 		return err


### PR DESCRIPTION
This is needed as MinIO SDK has to have trusted CA to access on https