### PR TITLE
close containerd client connection to avoid socket leak

### DIFF
--- a/nodelet/pkg/phases/container_runtime/start_containerd.go
+++ b/nodelet/pkg/phases/container_runtime/start_containerd.go
@@ -91,6 +91,7 @@ func (cp *ContainerdRunPhase) Stop(ctx context.Context, cfg config.Config) error
 		phaseutils.SetHostStatus(cp.hostPhase, constants.FailedState, err.Error())
 		return err
 	}
+	defer containerUtil.CloseClientConnection()
 
 	namespaces := []string{constants.K8sNamespace, constants.MobyNamespace}
 	err = containerUtil.DestroyContainersInNamespacesList(ctx, namespaces)

--- a/nodelet/pkg/utils/container_runtime/container_runtime.go
+++ b/nodelet/pkg/utils/container_runtime/container_runtime.go
@@ -18,19 +18,10 @@ type ContainerUtils interface {
 	CreateContainer(ctx context.Context, containerName string, containerImage string) (containerd.Container, error)
 	RemoveContainer(ctx context.Context, container containerd.Container, force bool) error
 	StopContainer(ctx context.Context, container containerd.Container, timeoutStr string) error
+	CloseClientConnection()
 }
 
 type ImageUtils interface {
 	LoadImagesFromDir(context.Context, string, string) error
 	LoadImagesFromFile(context.Context, string) error
 }
-
-// type InstallRuntime interface {
-// 	EnsureContainerdInstalled(ctx context.Context) error
-// 	EnsureRuncInstalled() error
-// 	EnsureCNIPluginsInstalled() error
-// 	LoadKernelModules(ctx context.Context, modules []string) error
-// 	SetContainerdSysctlParams(ctx context.Context) error
-// 	GenerateContainerdUnit() error
-// 	GenerateContainerdConfig() error
-// }

--- a/nodelet/pkg/utils/container_runtime/container_utils.go
+++ b/nodelet/pkg/utils/container_runtime/container_utils.go
@@ -23,7 +23,7 @@ type ContainerUtility struct {
 	log     *zap.SugaredLogger
 }
 
-const timeOut = "10s"
+const TimeOut = "10s"
 
 func NewContainerUtil() (ContainerUtils, error) {
 
@@ -49,9 +49,20 @@ func NewContainerdClient() (*containerd.Client, error) {
 	return containerdclient, nil
 }
 
+func (c *ContainerUtility) CloseClientConnection() {
+	if c.Client != nil {
+		err := c.Client.Close()
+		if err != nil {
+			c.log.Warnf("couldn't close containerd client connection: %v", err)
+			return
+		}
+		c.log.Info("closed containerd client connection")
+	}
+}
+
 func (c *ContainerUtility) EnsureFreshContainerRunning(ctx context.Context, containerName string, containerImage string) error {
 
-	err := c.EnsureContainerDestroyed(ctx, containerName, timeOut)
+	err := c.EnsureContainerDestroyed(ctx, containerName, TimeOut)
 	if err != nil {
 		return err
 	}
@@ -168,7 +179,7 @@ func (c *ContainerUtility) DestroyContainersInNamespace(ctx context.Context, nam
 
 	ctx = namespaces.WithNamespace(ctx, namespace)
 
-	err = c.EnsureContainersDestroyed(ctx, containers, timeOut)
+	err = c.EnsureContainersDestroyed(ctx, containers, TimeOut)
 	if err != nil {
 		return errors.Wrapf(err, "could not destroy containers in namespace: %s", namespace)
 	}


### PR DESCRIPTION
closing containerd client connection.
this applies to container functions where we are making client connection to containerd.
also for image utils where we are importing images using this connection.