### PR TITLE
Use CA serial file if exists for cert generation to ensure unique certs

### DIFF
--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/defaults.env
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/defaults.env
@@ -50,6 +50,7 @@ fi
 # Certificate directory assumed by make-ca-cert.sh
 CERTS_DIR="${CONF_DST_DIR}/certs"
 MAX_CERTS_RETRIES=10
+CERTS_SERIAL_FILE="/etc/pf9/kube.srl"
 
 # TODO: make these configurable per cluster
 MASTER_NAME=kubernetes-master

--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/utils.sh
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/utils.sh
@@ -1152,6 +1152,11 @@ function teardown_certs()
         echo "Removing the certs directory"
         rm -rf "$CERTS_DIR" ;
     fi
+
+    if [ -f $CERTS_SERIAL_FILE ]; then
+        echo "Removing certs serial file"
+        rm -f $CERTS_SERIAL_FILE
+    fi
 }
 
 # Returns sed expression to replace a pattern. If the replacement string is


### PR DESCRIPTION
https://platform9.atlassian.net/browse/AIR-593

First, per openSSL command, nodelet should only use the -CAcreateserial on first signing, and thereafter use that file as arg to -CAserial. Openssl is supposed to use that file and increment serial by +1 for each cert it signs with a CA. So have nodelet use that file is exists. Also delete the serial file in stop phase of gen_certs

As for the location of the serial file... it SHOULD be in same folder as CA cert, and have same name as CA cert but with .srl extension. However, I discovered a bug in openSSL... https://github.com/openssl/openssl/blob/12ad22dd16ffe47f8cde3cddb84a160e8cdb3e30/apps/x509.c#L1065

```
    if (serialfile == NULL) {
        BUF_strlcpy(buf, CAfile, len);
        for (p = buf; *p; p++)
            if (*p == '.') {
                *p = '\0';
                break;
            }
        BUF_strlcat(buf, POSTFIX, len);
```

Tries to strip the CA path at first '.', to generate the <CA filename>.srl file. But if a folder contains . it stops and creates the serial file at that top lvl directory. 

As a result, /etc/pf9/kube.d/certs/rootCA.crt terminates as "/etc/pf9/kube", and OpenSSL creates the serial file at /etc/pf9/kube.srl. 