### PR TITLE
Do not reload image bundle if checksum matches

### DIFF
--- a/nodelet/pkg/phases/container_runtime/load_images_test.go
+++ b/nodelet/pkg/phases/container_runtime/load_images_test.go
@@ -84,13 +84,13 @@ var _ = Describe("Test Load user images to container runtime phase", func() {
 			assert.NotNil(GinkgoT(), reterr)
 			assert.Equal(GinkgoT(), err, reterr)
 		})
-		It("succeds if check is false and successfully loads images", func() {
+		It("succeeds if check is false and successfully loads images", func() {
 			fakeFileUtils.EXPECT().VerifyChecksum(fakeCfg.UserImagesDir).Return(false, nil).AnyTimes()
 			fakeImageUtils.EXPECT().LoadImagesFromDir(ctx, fakeCfg.UserImagesDir, constants.K8sNamespace).Return(nil).AnyTimes()
 			reterr := fakePhase.Status(ctx, *fakeCfg)
 			assert.Nil(GinkgoT(), reterr)
 		})
-		It("succeds if check is true", func() {
+		It("succeeds if check is true", func() {
 			fakeFileUtils.EXPECT().VerifyChecksum(fakeCfg.UserImagesDir).Return(true, nil).AnyTimes()
 			reterr := fakePhase.Status(ctx, *fakeCfg)
 			assert.Nil(GinkgoT(), reterr)
@@ -136,16 +136,23 @@ var _ = Describe("Test Load user images to container runtime phase", func() {
 				err := os.Remove("testdata/checksum/sha256sums.txt")
 				assert.Nil(GinkgoT(), err)
 			})
-			It("Fails if could not load images", func() {
+			It("Fails if checksum mismatches and could not load images", func() {
 				err := errors.New("error")
+				fakeFileUtils.EXPECT().VerifyChecksum(fakeCfg.UserImagesDir).Return(false, nil).AnyTimes()
 				fakeImageUtils.EXPECT().LoadImagesFromDir(ctx, fakeCfg.UserImagesDir, constants.K8sNamespace).Return(err).AnyTimes()
 				reterr := fakePhase.Start(ctx, *fakeCfg)
 				assert.NotNil(GinkgoT(), reterr)
 				assert.Equal(GinkgoT(), err, reterr)
 			})
-			It("Succeeds if loads images", func() {
+			It("Succeeds if checksum mismatches and it loads images", func() {
+				fakeFileUtils.EXPECT().VerifyChecksum(fakeCfg.UserImagesDir).Return(false, nil).AnyTimes()
 				fakeImageUtils.EXPECT().LoadImagesFromDir(ctx, fakeCfg.UserImagesDir, constants.K8sNamespace).Return(nil).AnyTimes()
 				reterr := fakePhase.Start(ctx, *fakeCfg)
+				assert.Nil(GinkgoT(), reterr)
+			})
+			It("succeeds if checksum matches", func() {
+				fakeFileUtils.EXPECT().VerifyChecksum(fakeCfg.UserImagesDir).Return(true, nil).AnyTimes()
+				reterr := fakePhase.Status(ctx, *fakeCfg)
 				assert.Nil(GinkgoT(), reterr)
 			})
 		})

--- a/nodeletctl/pkg/nodeletctl/nodeletctl.go
+++ b/nodeletctl/pkg/nodeletctl/nodeletctl.go
@@ -333,10 +333,14 @@ func ParseBootstrapConfig(cfgPath string) (*BootstrapConfig, error) {
 	}
 
 	if len(bootstrapConfig.DNS.InlineHosts) > 0 {
+		// If custom hosts are specified, save to /etc/pf9/hosts and upload to each node to use core CoreDNS
 		bootstrapConfig.DNS.HostsFile, err = WriteHostsFileForEntries(bootstrapConfig.ClusterId, bootstrapConfig.DNS.InlineHosts)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to generate custom hosts file: %s", err)
 		}
+	} else if bootstrapConfig.DNS.HostsFile == "" {
+		// If custom hosts and custom file are both empty, use local /etc/hosts as default
+		bootstrapConfig.DNS.HostsFile = "/etc/hosts"
 	}
 
 	return bootstrapConfig, nil

--- a/nodeletctl/pkg/nodeletctl/nodeletctl.go
+++ b/nodeletctl/pkg/nodeletctl/nodeletctl.go
@@ -123,10 +123,10 @@ func CreateCluster(cfgPath string) error {
 		return fmt.Errorf("Failed to Parse Cluster Config: %s", err)
 	}
 
-	clusterStateDir := filepath.Join(ClusterStateDir, clusterCfg.ClusterId)
-	if _, err := os.Stat(clusterStateDir); err == nil {
-		zap.S().Warnf("Found pre-existing cluster state directory %s, re-using certs. Consider removing or scale or upgrade operations", clusterStateDir)
-		fmt.Printf("Found pre-existing cluster state directory %s, re-using certs. Consider removing or scale or upgrade operations", clusterStateDir)
+	clusterStateCertsDir := filepath.Join(ClusterStateDir, clusterCfg.ClusterId, "certs")
+	if _, err := os.Stat(clusterStateCertsDir); err == nil {
+		zap.S().Warnf("Found pre-existing certs directory %s, re-using certs. Consider removing or scale or upgrade operations", clusterStateCertsDir)
+		fmt.Printf("Found pre-existing certs directory %s, re-using certs. Consider removing or scale or upgrade operations", clusterStateCertsDir)
 	}
 
 	masters, err := GetCurrentMasters(clusterCfg)


### PR DESCRIPTION
In start phase, check is checksum exists and matches previous. If so, don't load new container images. This was being done after reboot on a Start phase, so adds considerable time for node to come back up