### PR TITLE
Set both MasterIps for singlestack ipv6 for backwards compatability

### DIFF
--- a/nodeletctl/pkg/nodeletctl/config.go
+++ b/nodeletctl/pkg/nodeletctl/config.go
@@ -116,6 +116,11 @@ func setNodeletClusterCfg(cfg *BootstrapConfig, nodelet *NodeletConfig) {
 		} else {
 			nodelet.ServicesCidr = cfg.ServicesCidr
 		}
+		if nodelet.MasterIp == "" && nodelet.MasterIpv6 != "" {
+			nodelet.MasterIp = nodelet.MasterIpv6
+		} else if nodelet.MasterIpv6 == "" && nodelet.MasterIp != "" {
+			nodelet.MasterIpv6 = nodelet.MasterIp
+		}
 	} else {
 		// IPv4 only
 		nodelet.CalicoIP4 = "autodetect"


### PR DESCRIPTION
Previously, there was just masterIp field to specify the master IP. This was used for both IPv4 and IPv6 since it was single stack.

With the dualstack changes, there is a new field called masterIpV6 in the nodeletctl config. On a dualstack cluster, masterIp must be the IPv4 address and the masterIpV6 must be the IPv6 address.

I noticed that for single stack IPv6, both fields needed to be set otherwise different things break. This can be confusing. And For backwards compatability with config for single stack IPv6, allow using either old masterIp or newer masterIpv6. This change will set both to whichever field is non-empty.