### PR TITLE
AIR-689 Fix DNS IP on v4 only deployments

### DIFF
--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/setup_env_and_run_script.sh
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/setup_env_and_run_script.sh
@@ -97,7 +97,7 @@ else
         # Currently only set by nodeletctl/airctl
         export NODE_IP=$(ipv4_address_of_node)
         export API_SERVICE_IP=`bin/addr_conv -cidr "$SERVICES_CIDR" -pos 1`
-        export DNS_IP=`bin/addr_conv -cidr "$SERVICES_CIDR_V6" -pos 10`
+        export DNS_IP=`bin/addr_conv -cidr "$SERVICES_CIDR" -pos 10`
     fi
     export NODE_NAME=$(get_node_name)
 


### PR DESCRIPTION
DNS resolution works with this change:
```
[centos@vedant-airgap-rootless02 ~]$ kubectl exec -it decco-consul-consul-server-0 -- /bin/sh
/ # nslookup operator.minio.svc.cluster.local
Server:         10.21.0.10
Address:        10.21.0.10:53

Name:   operator.minio.svc.cluster.local
Address: 10.21.0.138
```