### PR TITLE
Set ownership of ClusterStateDir to sshuser after nodelet cluster create

### DIFF
--- a/nodeletctl/pkg/nodeletctl/nodeletctl.go
+++ b/nodeletctl/pkg/nodeletctl/nodeletctl.go
@@ -172,15 +172,15 @@ func CreateCluster(cfgPath string) error {
 		return fmt.Errorf("cluster failed: %s", err)
 	}
 
-	if err := clusterCfg.saveClusterConfig(); err != nil {
-		zap.S().Errorf("Failed to save cluster config: %s", err)
-		return err
-	}
-
 	// Set the ownership of ClusterStateDir dir to SSHUser from bootstrap config
 	if err := setClusterStateDirOwnership(clusterCfg.SSHUser); err != nil {
 		zap.S().Errorf("Failed to set ownership: %v", err)
 		return fmt.Errorf("failed to set ownership: %v", err)
+	}
+
+	if err := clusterCfg.saveClusterConfig(); err != nil {
+		zap.S().Errorf("Failed to save cluster config: %s", err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION

Testing:
Running the following commands passes with this fix.
sudo /opt/pf9/airctl/airctl --config /opt/pf9/airctl/conf/airctl-config.yaml advanced-ddu create-mgmt --verbose
sudo /opt/pf9/airctl/airctl --config /opt/pf9/airctl/conf/airctl-config.yaml init --verbose
/opt/pf9/airctl/airctl --config /opt/pf9/airctl/conf/airctl-config.yaml start --verbose