### PR TITLE
Fix master IP for ipv6 only kubeconfig

### DIFF
--- a/nodeletctl/pkg/nodeletctl/certs.go
+++ b/nodeletctl/pkg/nodeletctl/certs.go
@@ -217,10 +217,16 @@ func GenKubeconfig(cfg *BootstrapConfig) error {
 		ClientKeyData:  adminKeyB64,
 	}
 
-	if cfg.IPv6Enabled {
-		kubeconfigArgs.MasterIp = "[" + cfg.MasterIp + "]"
+	masterIp := cfg.MasterIp
+	if cfg.IPv6Enabled && !cfg.IPv4Enabled {
+		// For backwards compatability in ipv6-only, either MasterIp or MasterIpv6 can be specified
+		if masterIp == "" && cfg.MasterIpv6 != "" {
+			masterIp = cfg.MasterIpv6
+		}
+		kubeconfigArgs.MasterIp = "[" + masterIp + "]"
 	} else {
-		kubeconfigArgs.MasterIp = cfg.MasterIp
+		// For Ipv4 or dualstack, use the IPv4 master IP in kubeconfig
+		kubeconfigArgs.MasterIp = masterIp
 	}
 
 	if err := writeKubeconfigFile(kubeconfigArgs); err != nil {


### PR DESCRIPTION
Previously there was only a MasterIp field since we only supported ipv4 or ipv6. For dualstack, a new MasterIpv6 field was introduced. For backwards compatability with ipv6-only, either field can be specified.

The kubeconfig was only using the old field MasterIp as the server address. Fix this by using MasterIpv6 if MasterIp is empty in ipv6-only