### PR TITLE
AIR-760: Add support for SystemImages in Bootstrap config

### DIFF
--- a/nodeletctl/pkg/nodeletctl/config.go
+++ b/nodeletctl/pkg/nodeletctl/config.go
@@ -63,6 +63,7 @@ func setNodeletClusterCfg(cfg *BootstrapConfig, nodelet *NodeletConfig) {
 	nodelet.Mtu = cfg.MTU
 	nodelet.Privileged = cfg.Privileged
 	nodelet.UserImages = cfg.UserImages
+	nodelet.SystemImages = cfg.SystemImages
 	nodelet.CoreDNSHostsFile = cfg.DNS.HostsFile
 	nodelet.IPv4Enabled = cfg.IPv4Enabled
 	nodelet.IPv6Enabled = cfg.IPv6Enabled

--- a/nodeletctl/pkg/nodeletctl/config.go
+++ b/nodeletctl/pkg/nodeletctl/config.go
@@ -30,6 +30,7 @@ type NodeletConfig struct {
 	Privileged             string
 	NodeletRole            string
 	UserImages             []string
+	SystemImages           []string
 	CoreDNSHostsFile       string
 	IPv4Enabled            bool
 	IPv6Enabled            bool

--- a/nodeletctl/pkg/nodeletctl/deployer.go
+++ b/nodeletctl/pkg/nodeletctl/deployer.go
@@ -573,6 +573,14 @@ func (nd *NodeletDeployer) DeleteCniDir() error {
 	return nil
 }
 
+func (nd *NodeletDeployer) DeleteUserImagesFiles() error {
+	deleteCmd := "rm -rf " + filepath.Join(UserImagesDir, "*")
+	if _, _, err := nd.client.RunCommand(deleteCmd); err != nil {
+		return fmt.Errorf("failed to cleanup old user images files: %s", err)
+	}
+	return nil
+}
+
 func (nd *NodeletDeployer) UploadCertsAndRestartStack(wg *sync.WaitGroup) error {
 	defer wg.Done()
 

--- a/nodeletctl/pkg/nodeletctl/deployer.go
+++ b/nodeletctl/pkg/nodeletctl/deployer.go
@@ -644,17 +644,13 @@ func (nd *NodeletDeployer) UploadSystemImages() error {
 		if local {
 			mkdirCmd := "mkdir -p " + UserImagesDir
 			_, stderr, err := nd.client.RunCommand(mkdirCmd)
-			//mkdirCmd := exec.Command("mkdir", "-p", UserImagesDir)
-			//_, err := mkdirCmd.CombinedOutput()
 			if err != nil {
 				zap.S().Errorf("error creating UserImagesDir at %s: stderr: %s: %v", UserImagesDir, string(stderr), err)
 				return fmt.Errorf("error creating UserImagesDir at %s: %v", UserImagesDir, err)
 			}
 
-			//chownCmd := exec.Command("chown", fmt.Sprintf("%s:pf9group", NodeletUser), UserImagesDir)
 			chownCmd := fmt.Sprintf("chown %s:pf9group %s", NodeletUser, UserImagesDir)
 			_, stderr, err = nd.client.RunCommand(chownCmd)
-			//_, err = chownCmd.CombinedOutput()
 			if err != nil {
 				zap.S().Errorf("error changing ownder of UserImagesDir at %s to %s: stderr: %s: %v", UserImagesDir, NodeletUser, string(stderr), err)
 				return fmt.Errorf("error changing ownder of UserImagesDir at %s to %s: %v", UserImagesDir, NodeletUser, err)
@@ -663,7 +659,6 @@ func (nd *NodeletDeployer) UploadSystemImages() error {
 			// Create symlink on local nodes to save disk space
 			symlinkPath := filepath.Join(UserImagesDir, filepath.Base(systemImage))
 			symlinkCmd := fmt.Sprintf("ln -s %s %s", systemImage, symlinkPath)
-			//err = os.Symlink(systemImage, symlinkPath)
 			_, stderr, err = nd.client.RunCommand(symlinkCmd)
 			if err != nil {
 				return fmt.Errorf("error creating symlink from %s to dest: %s: stderr: %s, %v", systemImage, symlinkPath, string(stderr), err)

--- a/nodeletctl/pkg/nodeletctl/nodeletctl.go
+++ b/nodeletctl/pkg/nodeletctl/nodeletctl.go
@@ -248,6 +248,10 @@ func DeployCluster(clusterCfg *BootstrapConfig) error {
 			deployer: deployer,
 		}
 
+		if err = deployer.DeleteUserImagesFiles(); err != nil {
+			zap.S().Warnf("failed cleaning up user images: %v, maybe because the dir doesnt exist", err)
+		}
+
 		converged, err := deployer.SpawnMaster(numMaster)
 		zap.S().Infof("Master status: %s\n", converged)
 		if err != nil {
@@ -349,6 +353,10 @@ func UpgradeCluster(cfgPath string) error {
 			deployer: deployer,
 		}
 
+		if err := deployer.DeleteUserImagesFiles(); err != nil {
+			SetClusterNodeStatus(deployer.clusterStatus, deployer.nodeletCfg.HostId, "failed", err)
+		}
+
 		if err := deployer.UpgradeMaster(); err != nil {
 			SetClusterNodeStatus(deployer.clusterStatus, deployer.nodeletCfg.HostId, "failed", err)
 		}
@@ -392,6 +400,11 @@ func UpgradeWorkers(clusterCfg *BootstrapConfig, clusterStatus *ClusterStatus) e
 		clusterStatus.statusMap[host.NodeName] = &NodeStatus{
 			deployer: deployer,
 		}
+
+		if err = deployer.DeleteUserImagesFiles(); err != nil {
+			return err
+		}
+
 		wg.Add(1)
 		go deployer.UpgradeWorker(&wg)
 	}
@@ -741,6 +754,11 @@ func DeployWorkers(clusterCfg *BootstrapConfig, clusterStatus *ClusterStatus, wo
 		clusterStatus.statusMap[host.NodeName] = &NodeStatus{
 			deployer: deployer,
 		}
+
+		if err = deployer.DeleteUserImagesFiles(); err != nil {
+			zap.S().Warnf("failed cleaning up user images: %v, maybe because the dir doesnt exist", err)
+		}
+
 		wg.Add(1)
 		zap.S().Infof("Adding worker %s to cluster %s", host.NodeName, clusterCfg.ClusterId)
 		go deployer.SpawnWorker(&wg)

--- a/nodeletctl/pkg/nodeletctl/nodeletctl.go
+++ b/nodeletctl/pkg/nodeletctl/nodeletctl.go
@@ -32,6 +32,7 @@ type BootstrapConfig struct {
 	Privileged             string                 `json:"privileged,omitempty"`
 	ContainerRuntime       ContainerRuntimeConfig `json:"containerRuntime,omitempty"`
 	UserImages             []string               `json:"userImages,omitempty"`
+	SystemImages           []string               `json:"systemImages,omitempty"`
 	DNS                    CoreDNSConfig          `json:"dns,omitempty"`
 	UseHostname            bool                   `json:"useHostname,omitempty"`
 	IPv4Enabled            bool                   `json:"ipv4,omitempty"`


### PR DESCRIPTION
Changes:
1. Added SystemImages in Bootstrap config. SystemImages are supposed to be used for Required Images needed for nodelet cluster to work in airgapped env.
2. SystemImages are symlinked in local node instead of actual upload. Remote node behaviour remains the same.
3. All files inside UserImagesDir(/var/opt/pf9/images/) are deleted during `create-mgmt` and `upgrade-mgmt` commands, before new SystemImages and UserImages are uploaded.

Testing:
verified the symlink worked for local nodes.
[centos@test-pf9-du-host-airgap-c7-mm-2538789-130-3 images]$ ls -al
total 0
drwxr-xr-x. 2 pf9 pf9group 91 Feb  6 08:35 .
drwxr-xr-x. 4 pf9 pf9group 51 Feb  6 08:36 ..
lrwxrwxrwx. 1 pf9 pf9group 55 Feb  6 08:35 kubedu-imgs-v-5.6.5-2543040.tar.gz -> /opt/pf9/airctl/imgs/kubedu-imgs-v-5.6.5-2543040.tar.gz
lrwxrwxrwx. 1 pf9 pf9group 56 Feb  6 08:35 nodelet-imgs-v-5.6.5-2543040.tar.gz -> /opt/pf9/airctl/imgs/nodelet-imgs-v-5.6.5-2543040.tar.gz

