### PR TITLE
edit .gitignore, stat for userImages, AIR-662

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ build/
 *.vscode*
 *.code-workspace
 *junit.xml
+
+# IDE stuff
+.vscode
+.idea

--- a/nodeletctl/pkg/nodeletctl/nodeletctl.go
+++ b/nodeletctl/pkg/nodeletctl/nodeletctl.go
@@ -239,6 +239,17 @@ func DeployCluster(clusterCfg *BootstrapConfig) error {
 					zap.S().Error(retErr)
 					return retErr
 				}
+				return err
+			}
+		}
+		for _, path := range nodeletCfg.SystemImages {
+			if _, err := os.Stat(path); err != nil {
+				if os.IsNotExist(err) {
+					retErr := fmt.Errorf("invalid SystemImage path in nodelet config %s, %w", path, err)
+					zap.S().Error(retErr)
+					return retErr
+				}
+				return err
 			}
 		}
 		nodeletSrcFile, err := GenNodeletConfigLocal(nodeletCfg, masterNodeletConfigTmpl)

--- a/nodeletctl/pkg/nodeletctl/nodeletctl.go
+++ b/nodeletctl/pkg/nodeletctl/nodeletctl.go
@@ -232,7 +232,15 @@ func DeployCluster(clusterCfg *BootstrapConfig) error {
 		nodeletCfg.NodeletRole = "master"
 		nodeletCfg.MasterList = &masterList
 		nodeletCfg.EtcdClusterState = "new"
-
+		for _, path := range nodeletCfg.UserImages {
+			if _, err := os.Stat(path); err != nil {
+				if os.IsNotExist(err) {
+					retErr := fmt.Errorf("invalid UserImage path in nodelet config %s, %w", path, err)
+					zap.S().Error(retErr)
+					return retErr
+				}
+			}
+		}
 		nodeletSrcFile, err := GenNodeletConfigLocal(nodeletCfg, masterNodeletConfigTmpl)
 		if err != nil {
 			zap.S().Infof("Failed to generate config: %s", err)


### PR DESCRIPTION
Fixes: https://platform9.atlassian.net/browse/AIR-662

Fix: Stat for paths in userImages list and error out if an image path is invalid

Sample run:
```log
[centos@rrajaknodeinstance imgs]$ cd ~/repos/airctl/build/
[centos@rrajaknodeinstance build]$ ./airctl --config ~/repos/airctl/conf/airctl-config-example.yaml advanced-ddu create-mgmt --verbose
2023-03-01T07:55:39.534Z	debug	Logger started
2023-03-01T07:55:39.535Z	info	Using config file:/home/centos/repos/airctl/conf/airctl-config-example.yaml
2023-03-01T07:55:39.535Z	info	Route: <nil> via 172.20.7.1 dev eth0 src <nil>

2023-03-01T07:55:39.535Z	info	Using external IP = 172.20.7.158

2023-03-01T07:55:39.535Z	info	Updating Bootstrap config at path: /home/centos/repos/airctl/build/cfg.yaml
2023-03-01T07:55:39.536Z	info	airctl version is v-5.6.0-0
2023-03-01T07:55:39.536Z	info	Adding kubedu images at /home/centos/the-one-that-works/imgs/kubedu-imgs-v-5.6.0-0.tar.gz to SystemImages
2023-03-01T07:55:39.536Z	info	Adding nodelet images at /home/centos/the-one-that-works/imgs/nodelet-imgs-v-5.6.0-0.tar.gz to SystemImages
2023-03-01T07:55:39.536Z	warn	Skipping image /home/centos/the-one-that-works/kubedu-imgs-v-5.6.6-2564285.tar.gz from UserImages as kubedu and nodelet images will be added by default based on the version
2023-03-01T07:55:39.536Z	info	ParseBootstrapConfig cfgPath: /home/centos/repos/airctl/build/cfg.yaml
2023-03-01T07:55:39.537Z	info	Deploying cluster airctl-mgmt
2023-03-01T07:55:39.537Z	info	Certs don't exist, generating new: /etc/nodelet/airctl-mgmt/certs

2023-03-01T07:55:43.488Z	warn	failed to remove root ca: exit status 1 - rm: cannot remove '/etc/pki/ca-trust/source/anchors/nodelet-ca.pem': No such file or directory

2023-03-01T07:55:48.666Z	info	Wrote kubeconfig to /etc/nodelet/airctl-mgmt/certs/admin.kubeconfig

2023-03-01T07:55:48.666Z	info	Deploying master node 10.128.241.85
2023-03-01T07:55:48.666Z	error	invalid UserImage path in nodelet config /home/centos/dne, stat /home/centos/dne: no such file or directory
2023-03-01T07:55:48.666Z	info	Cluster failed: invalid UserImage path in nodelet config /home/centos/dne, stat /home/centos/dne: no such file or directory


Failed to create nodelet cluster: cluster failed: invalid UserImage path in nodelet config /home/centos/dne, stat /home/centos/dne: no such file or directory
Error: cluster failed: invalid UserImage path in nodelet config /home/centos/dne, stat /home/centos/dne: no such file or directory
```