### PR TITLE
AIR-896 Changing permissions of kubeconfig dir.

### DIFF
--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/phases/prepare_kube_configs.sh
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/phases/prepare_kube_configs.sh
@@ -16,6 +16,7 @@ fi
 [ "$DEBUG" == "true" ] && set -x
 
 function start() {
+    local config_dir="/etc/pf9/kube.d/kubeconfigs"
     if [ "$ROLE" == "master" ]; then
         kustomize_config
         prepare_conf_files
@@ -25,6 +26,10 @@ function start() {
     if [ "$ROLE" == "master" ]; then
         prepare_rolebindings
     fi
+
+    # Make the config directory read write executable
+    chmod -R 0600 $config_dir
+    chmod 0700 $config_dir
 }
 
 function stop() {

--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/phases/prepare_kube_configs.sh
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/phases/prepare_kube_configs.sh
@@ -29,7 +29,6 @@ function start() {
 
     # Make the config directory read write executable
     chmod -R 0600 $config_dir
-    chmod 0700 $config_dir
 }
 
 function stop() {

--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/phases/prepare_kube_configs.sh
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/phases/prepare_kube_configs.sh
@@ -27,7 +27,7 @@ function start() {
         prepare_rolebindings
     fi
 
-    # Make the config directory read write executable
+    # Allow read, write on the config dir by owner but not by group, others
     chmod -R 0600 $config_dir
 }
 


### PR DESCRIPTION
[AIR-896](https://platform9.atlassian.net/browse/AIR-896)

**Summary:**  If the kubeconfig under /etc/pf9/kube.d/kubeconfigs/admin.yaml is used, then running helm command is giving warnings, due to which airctl upgrade is failing. Therefore, changing its file permissions from 644 to 600. 

[AIR-896]: https://platform9.atlassian.net/browse/AIR-896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

**Testing:**  
Just verified by changing its permissions on one of the setups. 
```
[centos@vedant-airgap-centos ~]$ export KUBECONFIG=/etc/pf9/kube.d/kubeconfigs/admin.yaml 
[centos@vedant-airgap-centos ~]$ helm version
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /etc/pf9/kube.d/kubeconfigs/admin.yaml
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /etc/pf9/kube.d/kubeconfigs/admin.yaml
version.BuildInfo{Version:"v3.9.0", GitCommit:"7ceeda6c585217a19a1131663d8cd1f7d641b2a7", GitTreeState:"clean", GoVersion:"go1.17.5"}
[centos@vedant-airgap-centos kubeconfigs]$ ls -lrt
total 40
-rw-r--r--. 1 root root 7936 Feb 21 12:38 kube-controller-manager.yaml
-rw-r--r--. 1 root root 7866 Feb 21 12:38 kube-scheduler.yaml
-rw-r--r--. 1 root root 7586 Feb 21 12:38 kubelet.yaml
-rw-r--r--. 1 root root 7596 Feb 21 12:38 kube-proxy.yaml
-rw-r--r--. 1 root root 7885 Feb 21 12:38 admin.yaml
[centos@vedant-airgap-centos kubeconfigs]$ sudo chmod -R 0600 admin.yaml 
[centos@vedant-airgap-centos kubeconfigs]$ ls -lrt
total 40
-rw-r--r--. 1 root root 7936 Feb 21 12:38 kube-controller-manager.yaml
-rw-r--r--. 1 root root 7866 Feb 21 12:38 kube-scheduler.yaml
-rw-r--r--. 1 root root 7586 Feb 21 12:38 kubelet.yaml
-rw-r--r--. 1 root root 7596 Feb 21 12:38 kube-proxy.yaml
-rw-------. 1 root root 7885 Feb 21 12:38 admin.yaml
[centos@vedant-airgap-centos kubeconfigs]$ helm version
version.BuildInfo{Version:"v3.9.0", GitCommit:"7ceeda6c585217a19a1131663d8cd1f7d641b2a7", GitTreeState:"clean", GoVersion:"go1.17.5"}
```