### PR TITLE
AIR-896[Backport-to-main] Changing permissions of kubeconfig dir.

### DIFF
--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/phases/prepare_kube_configs.sh
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/phases/prepare_kube_configs.sh
@@ -16,6 +16,7 @@ fi
 [ "$DEBUG" == "true" ] && set -x
 
 function start() {
+    local config_dir="/etc/pf9/kube.d/kubeconfigs"
     if [ "$ROLE" == "master" ]; then
         kustomize_config
         prepare_conf_files
@@ -25,6 +26,9 @@ function start() {
     if [ "$ROLE" == "master" ]; then
         prepare_rolebindings
     fi
+
+    # Allow read, write on the config dir by owner but not by group, others
+    chmod -R 0600 $config_dir
 }
 
 function stop() {


### PR DESCRIPTION
Backport of [this PR](https://github.com/platform9/nodelet/pull/102) on v1.0 branch. 