### PR TITLE
k8s.gcr.io is being deprecated for the newer registry.k8s.io

### DIFF
--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/master_utils.sh
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/master_utils.sh
@@ -332,7 +332,7 @@ function prepare_conf_files()
 
     # Image registries
     local quay_registry="${QUAY_PRIVATE_REGISTRY:-quay.io}"
-    local k8s_registry="${K8S_PRIVATE_REGISTRY:-k8s.gcr.io}"
+    local k8s_registry="${K8S_PRIVATE_REGISTRY:-registry.k8s.io}"
     local gcr_registry="${GCR_PRIVATE_REGISTRY:-gcr.io}"
     local docker_registry="${DOCKER_PRIVATE_REGISTRY}"
 
@@ -1004,7 +1004,7 @@ function ensure_dns()
 {
     local coredns_template="${CONF_SRC_DIR}/networkapps/coredns.yaml"
     local coredns_file="${CONF_SRC_DIR}/networkapps/coredns-applied.yaml"
-    local k8s_registry="${K8S_PRIVATE_REGISTRY:-k8s.gcr.io}"
+    local k8s_registry="${K8S_PRIVATE_REGISTRY:-registry.k8s.io}"
 
     # Replace configuration values in calico spec with user input
     sed -e "s|__DNS_IP__|${DNS_IP}|g" \

--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/utils.sh
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/utils.sh
@@ -539,7 +539,7 @@ function ensure_kubelet_running()
     local node_name=$1
     local kubeconfig="/etc/pf9/kube.d/kubeconfigs/kubelet.yaml"
     local log_dir_path="/var/log/pf9/kubelet/"
-    local k8s_registry="${K8S_PRIVATE_REGISTRY:-k8s.gcr.io}"
+    local k8s_registry="${K8S_PRIVATE_REGISTRY:-registry.k8s.io}"
     local pause_img="${k8s_registry}/pause:3.6"
 
     prepare_kubelet_bootstrap_config
@@ -707,7 +707,7 @@ function ensure_proxy_running()
         --privileged \
         --volume ${kubeconfig}:${kubeconfig_in_container}"
 
-    local k8s_registry="${K8S_PRIVATE_REGISTRY:-k8s.gcr.io}"
+    local k8s_registry="${K8S_PRIVATE_REGISTRY:-registry.k8s.io}"
     local container_name="proxy"
     local container_img="${k8s_registry}/kube-proxy:$KUBERNETES_VERSION"
 

--- a/nodelet/pkg/utils/constants/constants.go
+++ b/nodelet/pkg/utils/constants/constants.go
@@ -128,7 +128,7 @@ var (
 	// MobyNamespace is namespace for docker
 	MobyNamespace = "moby"
 	// K8sRegistry represents registry for official images for kubernetes
-	K8sRegistry = "k8s.gcr.io"
+	K8sRegistry = "registry.k8s.io"
 
 	// Kubelet related variables from defaults.env
 	KubeletDataDir          = "/var/lib/kubelet"


### PR DESCRIPTION
[PMK-5705](https://platform9.atlassian.net/browse/PMK-5705): k8s.gcr.io redirect to registry.k8s.io

k8s.gcr.io is being deprecated and moved to the newer community maintained registry.k8s.io

[PMK-5705]: https://platform9.atlassian.net/browse/PMK-5705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ