### PR TITLE
Add custom pause image config to containerd

### DIFF
--- a/nodelet/pkg/pf9kube/pf9/pf9-kube/os.sh
+++ b/nodelet/pkg/pf9kube/pf9/pf9-kube/os.sh
@@ -53,6 +53,8 @@ function configure_docker()
 function containerd_config()
 {
     echo "Generating config.toml"
+    local k8s_registry="${K8S_PRIVATE_REGISTRY:-registry.k8s.io}"
+    local pause_img="${k8s_registry}/pause:3.6"
     mkdir -p /etc/containerd
     cat > "/etc/containerd/config.toml" <<EOF
 version = 2
@@ -64,6 +66,7 @@ required_plugins = []
 oom_score = 0
 [plugins]
   [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "$pause_img"
     [plugins."io.containerd.grpc.v1.cri".registry]
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."platform9.io"]


### PR DESCRIPTION
The node comes up with this change:

```
[root@test-pf9-du-host-airgap-c7-2734343-280 pf9-kube]# kubectl get nodes
NAME             STATUS   ROLES    AGE     VERSION
10.128.144.122   Ready    master   3m32s   v1.21.3
```