### PR TITLE
Adding IsAirgapped flag in nodelet config

### DIFF
--- a/nodeletctl/pkg/nodeletctl/config.go
+++ b/nodeletctl/pkg/nodeletctl/config.go
@@ -53,6 +53,7 @@ type NodeletConfig struct {
 	ContainersCidr         string
 	ServicesCidr           string
 	ServicesCidrV6         string
+	IsAirgapped            bool
 }
 
 func setNodeletClusterCfg(cfg *BootstrapConfig, nodelet *NodeletConfig) {
@@ -73,6 +74,7 @@ func setNodeletClusterCfg(cfg *BootstrapConfig, nodelet *NodeletConfig) {
 	nodelet.IPv4Enabled = cfg.IPv4Enabled
 	nodelet.IPv6Enabled = cfg.IPv6Enabled
 	nodelet.Dualstack = cfg.IPv4Enabled && cfg.IPv6Enabled
+	nodelet.IsAirgapped = cfg.IsAirgapped
 
 	//Set default Calico opts first
 	nodelet.CalicoV4Interface = cfg.Calico.V4Interface

--- a/nodeletctl/pkg/nodeletctl/nodeletctl.go
+++ b/nodeletctl/pkg/nodeletctl/nodeletctl.go
@@ -15,71 +15,72 @@ import (
 )
 
 type BootstrapConfig struct {
-	SSHUser                string                 `json:"sshUser,omitempty"`
-	SSHPrivateKeyFile      string                 `json:"sshPrivateKeyFile,omitempty"`
-	CertsDir               string                 `json:"certsDir,omitempty"`
-	KubeConfig             string                 `json:"kubeconfig,omitempty"`
-	Pf9KubePkg             string                 `json:"nodeletPkg,omitempty"`
-	ClusterId              string                 `json:"clusterName,omitempty"`
-	AllowWorkloadsOnMaster bool                   `json:"allowWorkloadsOnMaster,omitempty"`
-	K8sApiPort             string                 `json:"k8sApiPort,omitempty"`
-	MasterIp               string                 `json:"masterIp,omitempty"`
-	MasterIpv6             string                 `json:"masterIpV6,omitempty"`
-	MasterVipEnabled       bool                   `json:"masterVipEnabled,omitempty"`
-	MasterVipInterface     string                 `json:"masterVipInterface,omitempty"`
-	MasterVipVrouterId     int                    `json:"masterVipVrouterId,omitempty"`
-	MTU                    string                 `json:"mtu,omitempty"`
-	Privileged             string                 `json:"privileged,omitempty"`
-	ContainerRuntime       ContainerRuntimeConfig `json:"containerRuntime,omitempty"`
-	UserImages             []string               `json:"userImages,omitempty"`
-	SystemImages           []string               `json:"systemImages,omitempty"`
-	DNS                    CoreDNSConfig          `json:"dns,omitempty"`
-	UseHostname            bool                   `json:"useHostname,omitempty"`
-	IPv4Enabled            bool                   `json:"ipv4,omitempty"`
-	IPv6Enabled            bool                   `json:"ipv6,omitempty"`
-	Calico                 CalicoConfig           `json:"calico,omitempty"`
-	ServicesCidr           string                 `json:"servicesCidr,omitempty"`
-	ServicesCidrV6         string                 `json:"servicesCidrV6,omitempty"`
-	EtcdConfig             EtcdConfig             `json:"etcdConfig,omitempty"`
-	MasterNodes            []HostConfig           `json:"masterNodes"`
-	WorkerNodes            []HostConfig           `json:"workerNodes"`
+	SSHUser                string                 `json:"sshUser,omitempty" survey:"sshUser"`
+	SSHPrivateKeyFile      string                 `json:"sshPrivateKeyFile,omitempty" survey:"sshPrivateKeyFile"`
+	CertsDir               string                 `json:"certsDir,omitempty" survey:"certsDir"`
+	KubeConfig             string                 `json:"kubeconfig,omitempty" survey:"kubeconfig"`
+	Pf9KubePkg             string                 `json:"pf9KubePkg,omitempty" survey:"pf9KubePkg"`
+	ClusterId              string                 `json:"clusterId,omitempty" survey:"clusterId"`
+	AllowWorkloadsOnMaster bool                   `json:"allowWorkloadsOnMaster,omitempty" survey:"allowWorkloadsOnMaster"`
+	K8sApiPort             string                 `json:"k8sApiPort,omitempty" survey:"k8sApiPort"`
+	MasterIp               string                 `json:"masterIp,omitempty" survey:"masterIp"`
+	MasterIpv6             string                 `json:"masterIpV6,omitempty" survey:"masterIpV6"`
+	MasterVipEnabled       bool                   `json:"masterVipEnabled,omitempty" survey:"masterVipEnabled"`
+	MasterVipInterface     string                 `json:"masterVipInterface,omitempty" survey:"masterVipInterface"`
+	MasterVipVrouterId     int                    `json:"masterVipVrouterId,omitempty" survey:"masterVipVrouterId"`
+	MTU                    string                 `json:"mtu,omitempty" survey:"mtu"`
+	Privileged             string                 `json:"privileged,omitempty" survey:"privileged"`
+	ContainerRuntime       ContainerRuntimeConfig `json:"containerRuntime,omitempty" survey:"containerRuntime"`
+	UserImages             []string               `json:"userImages,omitempty" survey:"userImages"`
+	SystemImages           []string               `json:"systemImages,omitempty" survey:"systemImages"`
+	DNS                    CoreDNSConfig          `json:"dns,omitempty" survey:"dns"`
+	UseHostname            bool                   `json:"useHostname,omitempty" survey:"useHostname"`
+	IPv4Enabled            bool                   `json:"ipv4Enabled,omitempty" survey:"ipv4"`
+	IPv6Enabled            bool                   `json:"ipv6Enabled,omitempty" survey:"ipv6"`
+	Calico                 CalicoConfig           `json:"calico,omitempty" survey:"calico"`
+	ServicesCidr           string                 `json:"servicesCidr,omitempty" survey:"servicesCidr"`
+	ServicesCidrV6         string                 `json:"servicesCidrV6,omitempty" survey:"servicesCidrV6"`
+	EtcdConfig             EtcdConfig             `json:"etcdConfig,omitempty" survey:"etcdConfig"`
+	MasterNodes            []HostConfig           `json:"masterNodes" survey:"masterNodes"`
+	WorkerNodes            []HostConfig           `json:"workerNodes" survey:"workerNodes"`
+	IsAirgapped            bool                   `json:"isAirgapped" survey:"isAirgapped"`
 }
 
 type EtcdConfig struct {
-	DataDir           string `json:"dataDir,omitempty"`
-	DiscoveryUrl      string `json:"discoveryUrl,omitempty"`
-	ElectionTimeout   int    `json:"electionTimeout,omitempty"`
-	HeartbeatInterval int    `json:"heartbeatInterval,omitempty"`
-	Version           string `json:"version,omitempty"`
+	DataDir           string `json:"dataDir,omitempty" survey:"dataDir"`
+	DiscoveryUrl      string `json:"discoveryUrl,omitempty" survey:"discoveryUrl"`
+	ElectionTimeout   int    `json:"electionTimeout,omitempty" survey:"electionTimeout"`
+	HeartbeatInterval int    `json:"heartbeatInterval,omitempty" survey:"heartbeatInterval"`
+	Version           string `json:"version,omitempty" survey:"version"`
 }
 
 type CalicoConfig struct {
-	V4Interface      string `json:"v4Interface,omitempty"`
-	V6Interface      string `json:"v6Interface,omitempty"`
-	V4ContainersCidr string `json:"v4ContainersCidr,omitempty"`
-	V6ContainersCidr string `json:"v6ContainersCidr,omitempty"`
-	V4BlockSize      int    `json:"v4BlockSize,omitempty"`
-	V6BlockSize      int    `json:"v6BlockSize,omitempty"`
-	V4NATOutgoing    bool   `json:"v4NATOutgoing,omitempty"`
-	V6NATOutgoing    bool   `json:"v6NATOutgoing,omitempty"`
-	V4IpIpMode       string `json:"v4IpIpMode,omitempty"`
+	V4Interface      string `json:"v4Interface,omitempty" survey:"v4Interface"`
+	V6Interface      string `json:"v6Interface,omitempty" survey:"v6Interface"`
+	V4ContainersCidr string `json:"v4ContainersCidr,omitempty" survey:"v4ContainersCidr"`
+	V6ContainersCidr string `json:"v6ContainersCidr,omitempty" survey:"v6ContainersCidr"`
+	V4BlockSize      int    `json:"v4BlockSize,omitempty" survey:"v4BlockSize"`
+	V6BlockSize      int    `json:"v6BlockSize,omitempty" survey:"v6BlockSize"`
+	V4NATOutgoing    bool   `json:"v4NATOutgoing,omitempty" survey:"v4NATOutgoing"`
+	V6NATOutgoing    bool   `json:"v6NATOutgoing,omitempty" survey:"v6NATOutgoing"`
+	V4IpIpMode       string `json:"v4IpIpMode,omitempty" survey:"v4IpIpMode"`
 }
 
 type CoreDNSConfig struct {
-	HostsFile   string   `json:"hostsFile,omitempty"`
-	InlineHosts []string `json:"corednsHosts,omitempty"`
+	HostsFile   string   `json:"hostsFile,omitempty" survey:"hostsFile"`
+	InlineHosts []string `json:"corednsHosts,omitempty" survey:"corednsHosts"`
 }
 
 type ContainerRuntimeConfig struct {
-	Name         string `json:"name,omitempty"`
-	CgroupDriver string `json:"cgroupDriver,omitempty"`
+	Name         string `json:"name,omitempty" survey:"name"`
+	CgroupDriver string `json:"cgroupDriver,omitempty" survey:"cgroupDriver"`
 }
 
 type HostConfig struct {
-	NodeName            string  `json:"nodeName"`
-	NodeIP              *string `json:"nodeIP,omitempty"`
-	V4InterfaceOverride *string `json:"calicoV4Interface,omitempty"`
-	V6InterfaceOverride *string `json:"calicoV6Interface,omitempty"`
+	NodeName            string  `json:"nodeName" survey:"nodeName"`
+	NodeIP              *string `json:"nodeIP,omitempty" survey:"nodeIP"`
+	V4InterfaceOverride *string `json:"calicoV4Interface,omitempty" survey:"calicoV4Interface"`
+	V6InterfaceOverride *string `json:"calicoV6Interface,omitempty" survey:"calicoV6Interface"`
 }
 
 type ClusterStatus struct {
@@ -182,12 +183,6 @@ func CreateCluster(cfgPath string) error {
 		return fmt.Errorf("cluster failed: %s", err)
 	}
 
-	// Set the ownership of ClusterStateDir dir to SSHUser from bootstrap config
-	if err := setClusterStateDirOwnership(clusterCfg.SSHUser); err != nil {
-		zap.S().Errorf("Failed to set ownership: %v", err)
-		return fmt.Errorf("failed to set ownership: %v", err)
-	}
-
 	if err := clusterCfg.saveClusterConfig(); err != nil {
 		zap.S().Errorf("Failed to save cluster config: %s", err)
 		return err
@@ -241,25 +236,32 @@ func DeployCluster(clusterCfg *BootstrapConfig) error {
 		nodeletCfg.NodeletRole = "master"
 		nodeletCfg.MasterList = &masterList
 		nodeletCfg.EtcdClusterState = "new"
-		for _, path := range nodeletCfg.UserImages {
-			if _, err := os.Stat(path); err != nil {
-				if os.IsNotExist(err) {
-					retErr := fmt.Errorf("invalid UserImage path in nodelet config %s, %w", path, err)
-					zap.S().Error(retErr)
-					return retErr
+		if nodeletCfg.IsAirgapped {
+			for _, path := range nodeletCfg.UserImages {
+				if _, err := os.Stat(path); err != nil {
+					if os.IsNotExist(err) {
+						retErr := fmt.Errorf("invalid UserImage path in nodelet config %s, %w", path, err)
+						zap.S().Error(retErr)
+						return retErr
+					}
+					return err
 				}
-				return err
+			}
+			for _, path := range nodeletCfg.SystemImages {
+				if _, err := os.Stat(path); err != nil {
+					if os.IsNotExist(err) {
+						retErr := fmt.Errorf("invalid SystemImage path in nodelet config %s, %w", path, err)
+						zap.S().Error(retErr)
+						return retErr
+					}
+					return err
+				}
 			}
 		}
-		for _, path := range nodeletCfg.SystemImages {
-			if _, err := os.Stat(path); err != nil {
-				if os.IsNotExist(err) {
-					retErr := fmt.Errorf("invalid SystemImage path in nodelet config %s, %w", path, err)
-					zap.S().Error(retErr)
-					return retErr
-				}
-				return err
-			}
+		// Set the ownership of ClusterStateDir dir to SSHUser from bootstrap config
+		if err := setClusterStateDirOwnership(clusterCfg.SSHUser); err != nil {
+			zap.S().Errorf("Failed to set ownership: %v", err)
+			return fmt.Errorf("failed to set ownership: %v", err)
 		}
 		nodeletSrcFile, err := GenNodeletConfigLocal(nodeletCfg, masterNodeletConfigTmpl)
 		if err != nil {


### PR DESCRIPTION
**Summary**:  Adding `IsAirgapped` param in the nodelet config to skip the check for userImages and systemImages in the config file.  Updating the nodelet config stuct to enable taking survey input using airctl and generate the nodelet-bootstrap-config file. 

**Testing:**  Was able to get the base nodelet cluster for connected mode using this. 
```
[centos@vedant-smcp-nodelet ~]$ /opt/pf9/pf9-kube/bin/kubectl get pods -A
NAMESPACE     NAME                                       READY   STATUS    RESTARTS   AGE
kube-system   calico-kube-controllers-5fcd6c885b-5cnqn   1/1     Running   0          4m48s
kube-system   calico-node-wcbng                          1/1     Running   0          4m45s
kube-system   calico-typha-84d9f8c679-pz29c              1/1     Running   0          4m48s
kube-system   calico-typha-autoscaler-846cfc7cdc-5z24l   1/1     Running   0          4m47s
kube-system   coredns-847c6b4c5f-w4t66                   1/1     Running   0          3m45s
kube-system   k8s-master-10.128.145.254                  3/3     Running   0          3m56s
kube-system   kube-dns-autoscaler-7c48b568c5-52mrv       1/1     Running   0          3m45s
```